### PR TITLE
Keep activity heatmap aligned across DST

### DIFF
--- a/InfoView.qml
+++ b/InfoView.qml
@@ -181,7 +181,9 @@ Item {
               height: Math.round(7 * 16 * Style.fontScale)
               property var cells: (view.ai.heatmap || {}).cells || []
               property real startTs: (view.ai.heatmap || {}).start || 0
+              property var days: (view.ai.heatmap || {}).days || []
               property int hoverIdx: -1
+              function dayTs(index) { return days[index] || (startTs + index * 86400000) }
               onCellsChanged: requestPaint()
               Connections { target: view.desk; function onGreenChanged() { heat.requestPaint() } function onThemeForegroundChanged() { heat.requestPaint() } }
               onPaint: {
@@ -194,7 +196,7 @@ Item {
                 ctx.textBaseline = "middle"
                 var days = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]
                 for (var d = 0; d < 7; d++) {
-                  var dt = new Date(startTs + d * 86400000)
+                  var dt = new Date(dayTs(d))
                   ctx.fillStyle = Qt.rgba(view.textFaint.r, view.textFaint.g, view.textFaint.b, view.textFaint.a)
                   ctx.fillText(days[dt.getDay()], 0, d * ch + ch / 2)
                   for (var h = 0; h < 24; h++) {
@@ -217,7 +219,11 @@ Item {
                   }
                 }
                 // "now" marker
-                var nowD = new Date(), nd = Math.floor((nowD.getTime() - startTs) / 86400000)
+                var nowD = new Date(), nd = -1
+                for (var di = 0; di < 7; di++) {
+                  var markerDay = new Date(dayTs(di))
+                  if (markerDay.getFullYear() === nowD.getFullYear() && markerDay.getMonth() === nowD.getMonth() && markerDay.getDate() === nowD.getDate()) { nd = di; break }
+                }
                 if (nd >= 0 && nd < 7) {
                   var nx = labelW + (nowD.getHours() + nowD.getMinutes() / 60) * cw
                   ctx.strokeStyle = Qt.rgba(view.desk.red.r, view.desk.red.g, view.desk.red.b, 0.8)
@@ -252,7 +258,7 @@ Item {
                   if (heat.hoverIdx < 0) return "hover a cell · red tick = now"
                   var c = heat.cells[heat.hoverIdx] || [0, {}]
                   var d = Math.floor(heat.hoverIdx / 24), h = heat.hoverIdx % 24
-                  var dt = new Date(heat.startTs + d * 86400000)
+                  var dt = new Date(heat.dayTs(d))
                   var parts = []; for (var k in c[1]) parts.push(view.desk.providerLabel(k) + " " + c[1][k])
                   return Qt.formatDate(dt, "ddd d MMM") + " " + (h < 10 ? "0" : "") + h + ":00 · " + c[0] + " prompts" + (parts.length ? " (" + parts.join(", ") + ")" : "")
                 }

--- a/collector.ts
+++ b/collector.ts
@@ -6,6 +6,7 @@
 
 import { readdirSync, readFileSync, statSync, existsSync, readlinkSync, mkdirSync, writeFileSync } from "fs";
 import { join, basename } from "path";
+import { localDayIndex, localDayStarts } from "./history-time";
 
 const HOME = process.env.HOME || "/root";
 const XDG_STATE = process.env.XDG_STATE_HOME || join(HOME, ".local/state");
@@ -205,8 +206,6 @@ async function liveSessions(pids: number[]) {
 }
 
 // ---------------------------------------------------------------- AI history
-const DAY = 86400000;
-function dayKey(ts: number) { const d = new Date(ts); return d.toISOString().slice(0, 10); }
 function heatmapInit() {
   // 7 days x 24 hours, local time, oldest first; each cell {total, byProvider}
   const cells: any[] = [];
@@ -214,10 +213,11 @@ function heatmapInit() {
   return cells;
 }
 const heat = heatmapInit();
-const start7 = (() => { const d = new Date(now); d.setHours(0, 0, 0, 0); return d.getTime() - 6 * DAY; })();
+const heatDays = localDayStarts(now, 7);
+const start7 = heatDays[0];
 function bump(ts: number, prov: string) {
   if (ts < start7 || ts > now + 60000) return;
-  const d = new Date(ts); const dayIdx = Math.floor((d.getTime() - start7) / DAY);
+  const d = new Date(ts); const dayIdx = localDayIndex(ts, heatDays);
   if (dayIdx < 0 || dayIdx > 6) return;
   const cell = heat[dayIdx * 24 + d.getHours()]; cell.n++; cell.p[prov] = (cell.p[prov] || 0) + 1;
 }
@@ -326,7 +326,7 @@ const snapshot = {
   },
   ai: {
     sessions, counts, providers: { claude, codex, grok, ollama }, usage: agentsUsage(),
-    heatmap: { start: start7, cells: heat.map(c => [c.n, c.p]) }, recent: recent.slice(0, 40),
+    heatmap: { start: start7, days: heatDays, cells: heat.map(c => [c.n, c.p]) }, recent: recent.slice(0, 40),
   },
 };
 

--- a/history-time.test.ts
+++ b/history-time.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { localDayIndex, localDayStarts } from "./history-time";
+
+describe("local history days", () => {
+  test("keeps local midnights aligned across spring DST", () => {
+    process.env.TZ = "America/New_York";
+    const days = localDayStarts(new Date("2026-03-10T12:00:00-04:00").getTime(), 4);
+    expect(days.map(value => new Date(value).getHours())).toEqual([0, 0, 0, 0]);
+    expect(days[2] - days[1]).toBe(23 * 60 * 60 * 1000);
+    expect(localDayIndex(new Date("2026-03-08T23:30:00-04:00").getTime(), days)).toBe(1);
+  });
+
+  test("keeps local midnights aligned across fall DST", () => {
+    process.env.TZ = "America/New_York";
+    const days = localDayStarts(new Date("2026-11-03T12:00:00-05:00").getTime(), 4);
+    expect(days.map(value => new Date(value).getHours())).toEqual([0, 0, 0, 0]);
+    expect(days[2] - days[1]).toBe(25 * 60 * 60 * 1000);
+    expect(localDayIndex(new Date("2026-11-01T23:30:00-05:00").getTime(), days)).toBe(1);
+  });
+});

--- a/history-time.ts
+++ b/history-time.ts
@@ -1,0 +1,21 @@
+export function localDayStarts(reference: number, count: number): number[] {
+  const day = new Date(reference);
+  day.setHours(0, 0, 0, 0);
+  day.setDate(day.getDate() - count + 1);
+  const starts: number[] = [];
+  for (let i = 0; i < count; i++) {
+    starts.push(day.getTime());
+    day.setDate(day.getDate() + 1);
+  }
+  return starts;
+}
+
+export function localDayIndex(timestamp: number, starts: number[]): number {
+  const value = new Date(timestamp);
+  return starts.findIndex(start => {
+    const day = new Date(start);
+    return day.getFullYear() === value.getFullYear()
+      && day.getMonth() === value.getMonth()
+      && day.getDate() === value.getDate();
+  });
+}


### PR DESCRIPTION
## Summary
- build the seven-day window from calendar-day increments instead of fixed 24-hour durations
- assign prompts to rows by local calendar date
- send explicit local-midnight timestamps to QML for labels, hover details, and the current-time marker
- retain a fallback for snapshots without the new day array
- test both spring-forward and fall-back transitions

## Verification
- `TZ=America/New_York bun test`
- `bun --check collector.ts`
- live collector snapshot: 7 day markers / 168 cells
- `git diff --check`