### PR TITLE
fix: honor omarchy.background IPC so theme-set updates the wallpaper immediately

### DIFF
--- a/Infomarchy.qml
+++ b/Infomarchy.qml
@@ -1,18 +1,23 @@
 import QtQuick
-import QtQuick.Effects
 import Quickshell
 import Quickshell.Io
 import Quickshell.Wayland
 import qs.Commons
+import qs.Ui
 
 // Background-layer host. Replaces omarchy.background (manifest clonedFrom), so
 // the theme's wallpaper is still shown — dimmed — behind the live dashboard,
-// and `omarchy-theme-bg-set` keeps working through the same IPC target.
+// and `omarchy-theme-bg-set` / `omarchy-theme-set` keep working through the
+// same IPC target. Omarchy's theme-set calls `background themeTransition`;
+// without that function the wallpaper lags on the 5s symlink poll and the
+// snapshot files theme-set deletes after 3s can win the race.
 Scope {
   id: root
 
+  // Match omarchy-theme-bg-set and Color.currentThemePath: $HOME/.local/state,
+  // not XDG_STATE_HOME, which can point somewhere the CLI never writes.
   readonly property string home: Quickshell.env("HOME")
-  readonly property string stateHome: Quickshell.env("XDG_STATE_HOME") || (home + "/.local/state")
+  readonly property string stateHome: home + "/.local/state"
   readonly property string currentBackgroundLink: stateHome + "/omarchy/current/background"
   property string background: ""
   // How much of the wallpaper survives under the glass. 0 = solid theme bg.
@@ -20,9 +25,23 @@ Scope {
 
   InfoModel { id: infoModel; refreshMs: 4000 }
 
-  function imageUrl(path) { return path ? "file://" + path : "" }
+  function imageUrl(path) { return Util.fileUrl(path) }
   function refreshBackground() { if (!readlinkProc.running) readlinkProc.running = true }
-  function setBackground(path) { root.background = String(path || "") }
+  function setBackground(path) { root.background = String(path || "").trim() }
+
+  function applyThemePayload(colorsB64, shellB64) {
+    try { Color.loadColors(Util.decodeBase64(colorsB64)) } catch (e) {}
+    try { Color.loadShell(Util.decodeBase64(shellB64)) } catch (e2) {}
+    Style.scheduleRefresh()
+  }
+
+  // theme-set passes a 3s snapshot as `path` and the durable symlink target as
+  // `finalPath`. We skip the stock wipe animation, so we must display
+  // finalPath — pointing at the snapshot would 404 after the cleanup rm.
+  function themeTransition(fromPath, path, finalPath, colorsB64, shellB64) {
+    root.setBackground(finalPath || path)
+    root.applyThemePayload(colorsB64, shellB64)
+  }
 
   Process {
     id: readlinkProc
@@ -42,6 +61,11 @@ Scope {
     target: "background"
     function refresh(): void { root.refreshBackground() }
     function set(path: string): void { root.setBackground(path) }
+    function setInstant(path: string): void { root.setBackground(path) }
+    function transition(fromPath: string, path: string): void { root.setBackground(path) }
+    function themeTransition(fromPath: string, path: string, finalPath: string, colorsB64: string, shellB64: string): void {
+      root.themeTransition(fromPath, path, finalPath, colorsB64, shellB64)
+    }
     function selector(): void { if (!bgSwitchProc.running) bgSwitchProc.running = true }
   }
   IpcHandler {
@@ -56,6 +80,9 @@ Scope {
       id: panel
       required property var modelData
       screen: modelData
+      // Hyprland leaves a mapped layer at its old global origin when a monitor
+      // moves (undock). Pulse unmapped so the compositor re-places us.
+      visible: !remapGuard.remapping
       anchors { top: true; bottom: true; left: true; right: true }
       color: infoModel.themeBackground
       WlrLayershell.namespace: "omarchy-background"
@@ -64,6 +91,11 @@ Scope {
       exclusionMode: ExclusionMode.Ignore
       // A parked background layer has been seen to drop its buffer; keep rendering.
       updatesEnabled: true
+
+      ScreenMoveRemap {
+        id: remapGuard
+        window: panel
+      }
 
       Image {
         anchors.fill: parent


### PR DESCRIPTION
## Why

Infomarchy `clonedFrom: omarchy.background`, so it **is** the wallpaper plugin. `omarchy-theme-set` calls:

```
omarchy-shell background themeTransition <from> <snapshot> <finalPath> <colorsB64> <shellB64>
```

That function did not exist. The CLI falls back to `shell applyTheme` (colors only). The wallpaper then waits up to 5 seconds for the symlink poll — and if we had bound the snapshot path, `theme-set` deletes those files after 3 seconds.

Stock `Background.qml` also remaps the layer when a monitor moves. We didn't, so undocking left the desk at the old global origin.

## What

- Implement the full `background` IPC contract: `setInstant`, `transition`, `themeTransition` (keep existing `refresh` / `set` / `selector`)
- `themeTransition` displays **`finalPath`**, not the 3s snapshot, and loads the theme via `Color.loadColors` / `Color.loadShell`
- `ScreenMoveRemap` on the background `PanelWindow` (same guard as stock)
- `Util.fileUrl` so spaces / special chars in wallpaper paths don't break `Image.source`
- Read `$HOME/.local/state/omarchy/current/background` like `omarchy-theme-bg-set` and `Color.currentThemePath` (not `XDG_STATE_HOME`, which can diverge)

Intentionally does **not** copy the stock wipe animation. Without it we must not point `Image.source` at a file `theme-set` is about to `rm`.

## Test plan

- [ ] `omarchy theme set <other-theme>` — wallpaper and desk colors change immediately, no 5s stall, no broken image
- [ ] `omarchy theme bg set <image>` — still instant (existing `set`)
- [ ] Undock / move a monitor — desk remaps onto the remaining screen
- [ ] Wallpaper path with a space still renders