### PR TITLE
fix: Esc dismisses overlay; bun stderr no longer paints as a collector error

### DIFF
--- a/InfoModel.qml
+++ b/InfoModel.qml
@@ -14,7 +14,12 @@ Item {
   property var snap: ({})
   property bool ready: false
   property string error: ""
-  property string pluginDir: Qt.resolvedUrl(".").toString().replace(/^file:\/\//, "")
+  // Resolve the script itself so a missing trailing slash on a directory URL
+  // cannot produce ".../nixfred.infomarchicollector.ts".
+  property string collectorPath: Qt.resolvedUrl("collector.ts").toString().replace(/^file:\/\//, "")
+  // Wallpaper and overlay each run a collector; --id keeps their rate
+  // baselines apart (see collector.ts prev-${id}.json).
+  property string instance: "bg"
 
   // --- theme ---------------------------------------------------------------
   // Omarchy's Color singleton gives fg/bg/accent/urgent/muted. The ANSI roles
@@ -75,6 +80,8 @@ Item {
       case "gemini": return root.blue
       case "ollama": return root.green
       case "opencode": return root.blue
+      case "aider": return root.yellow
+      case "copilot": return root.magenta
       default: return Color.accent
     }
   }
@@ -86,6 +93,8 @@ Item {
       case "gemini": return "Gemini"
       case "ollama": return "Ollama"
       case "opencode": return "opencode"
+      case "aider": return "Aider"
+      case "copilot": return "Copilot"
       default: return String(p)
     }
   }
@@ -93,7 +102,8 @@ Item {
   // --- collector -----------------------------------------------------------
   Process {
     id: collector
-    command: ["bun", root.pluginDir + "collector.ts"]
+    property string lastStderr: ""
+    command: ["bun", root.collectorPath, "--id", root.instance]
     stdout: StdioCollector {
       onStreamFinished: {
         var t = String(text || "").trim()
@@ -108,7 +118,13 @@ Item {
       }
     }
     stderr: StdioCollector {
-      onStreamFinished: { var t = String(text || "").trim(); if (t) root.error = t.split("\n")[0] }
+      // bun / libraries may warn on stderr even when the snapshot is valid.
+      // Stash it; only promote to the desk error banner if the process fails.
+      onStreamFinished: { collector.lastStderr = String(text || "").trim() }
+    }
+    onExited: function(exitCode) {
+      if (exitCode !== 0 && collector.lastStderr)
+        root.error = collector.lastStderr.split("\n")[0]
     }
   }
   function refresh() { if (root.active && !collector.running) collector.running = true }

--- a/Overlay.qml
+++ b/Overlay.qml
@@ -3,6 +3,7 @@ import Quickshell
 import Quickshell.Io
 import Quickshell.Wayland
 import qs.Commons
+import qs.Ui
 
 // Summonable fullscreen twin of the desk, for when windows cover the
 // wallpaper. Bind e.g. SUPER+D → `omarchy-shell shell toggle nixfred.infomarchy`.
@@ -11,11 +12,17 @@ Scope {
   id: root
   property bool opened: false
 
-  InfoModel { id: infoModel; refreshMs: 3000; active: root.opened }
+  InfoModel { id: infoModel; refreshMs: 3000; active: root.opened; instance: "overlay" }
 
-  function open(payload) { root.opened = true; infoModel.refresh() }
+  function open(payload) {
+    root.opened = true
+    infoModel.refresh()
+  }
   function close() { root.opened = false }
   function toggle(payload) { if (root.opened) close(); else open(payload) }
+  // `omarchy-shell shell call nixfred.infomarchy refresh` hits the overlay
+  // loader, not the wallpaper IpcHandler.
+  function refresh() { infoModel.refresh() }
 
   Variants {
     model: Quickshell.screens
@@ -23,7 +30,7 @@ Scope {
       id: panel
       required property var modelData
       screen: modelData
-      visible: root.opened
+      visible: root.opened && !remapGuard.remapping
       anchors { top: true; bottom: true; left: true; right: true }
       color: "transparent"
       WlrLayershell.namespace: "infomarchy-overlay"
@@ -31,11 +38,20 @@ Scope {
       WlrLayershell.keyboardFocus: root.opened ? WlrKeyboardFocus.Exclusive : WlrKeyboardFocus.None
       exclusionMode: ExclusionMode.Ignore
 
+      ScreenMoveRemap {
+        id: remapGuard
+        window: panel
+      }
+
       Rectangle {
+        id: keyCatcher
         anchors.fill: parent
         color: Util.alpha(infoModel.themeBackground, 0.88)
         focus: root.opened
         Keys.onEscapePressed: root.close()
+        // Exclusive keyboard focus on the layer is not enough — Qt still
+        // needs an item with activeFocus or Esc never fires.
+        onVisibleChanged: if (visible) Qt.callLater(function() { keyCatcher.forceActiveFocus() })
         MouseArea { anchors.fill: parent; onClicked: root.close() }
         InfoView {
           anchors.fill: parent

--- a/README.md
+++ b/README.md
@@ -161,8 +161,9 @@ No usernames, hostnames or absolute paths are hardcoded anywhere. The collector 
 ## Tuning
 
 ```bash
-omarchy-shell shell call nixfred.infomarchy refresh                   # refresh now
-quickshell ipc -p /usr/share/omarchy/shell call infomarchy setWallpaperOpacity 0.5   # 0 = solid theme bg
+omarchy-shell infomarchy refresh                                      # wallpaper collector now
+omarchy-shell shell call nixfred.infomarchy refresh                   # overlay collector (only while summoned)
+omarchy-shell infomarchy setWallpaperOpacity 0.5                      # 0 = solid theme bg
 ```
 
 | Knob | Where | Default |


### PR DESCRIPTION
## Why

1. **Esc did nothing.** Overlay set `WlrKeyboardFocus.Exclusive` but never `forceActiveFocus()` on a Qt item. Every other Omarchy overlay (emojis, clipboard, menu) does `Qt.callLater(forceActiveFocus)` on open. Only backdrop-click closed it.
2. **False error banner.** InfoModel's stderr `StdioCollector` set `root.error` whenever bun printed a warning. stdout and stderr `onStreamFinished` order is undefined, so a valid snapshot could still show `⚠` on LIVE AI SESSIONS.
3. **Documented refresh was `unknown`.** `omarchy-shell shell call nixfred.infomarchy refresh` goes through `shell.callIfLoaded` → overlay loader, not the wallpaper `IpcHandler`. Overlay had no `refresh()`.
4. **collector path.** `pluginDir + "collector.ts"` breaks if `Qt.resolvedUrl(".")` has no trailing slash.

## What

- `keyCatcher.forceActiveFocus()` when the overlay becomes visible
- `function refresh()` on the overlay Scope
- `Qt.resolvedUrl("collector.ts")` for the bun command
- Pass `--id overlay` / default `bg` (pairs with the collector PR; extra argv is ignored until that lands)
- Promote stderr to the error banner **only** on non-zero `onExited`
- `ScreenMoveRemap` on the overlay layer
- Aider / Copilot labels
- README IPC examples match the two real targets (`omarchy-shell infomarchy …` vs `shell call nixfred.infomarchy …`)

## Test plan

- [ ] SUPER+D → overlay → **Esc** dismisses it
- [ ] Click on the dim backdrop still dismisses; click on a card does not
- [ ] `omarchy-shell shell call nixfred.infomarchy refresh` returns `ok` while the overlay is loaded
- [ ] `omarchy-shell infomarchy refresh` still refreshes the wallpaper collector
- [ ] bun warnings (if any) no longer appear as `⚠` on the sessions card after a good snapshot