### PR TITLE
fix: Grok card keeps pulsing after the turn is done

### DIFF
--- a/InfoView.qml
+++ b/InfoView.qml
@@ -127,7 +127,9 @@ Item {
                 id: sc
                 required property var modelData
                 readonly property color tone: view.desk.providerColor(modelData.provider)
-                readonly property bool busy: modelData.window && /Processing|🧠|⚙|⏳|…/.test(String(modelData.window.title || ""))
+                // Prefer collector.busy (Grok's title sticks on 🧠 after the turn).
+                // Fall back to the title regex for snapshots from an older collector.
+                readonly property bool busy: modelData.busy === true || (modelData.busy !== false && modelData.window && /Processing|🧠|⚙|⏳|…/.test(String(modelData.window.title || "")))
                 width: Math.round(250 * Style.fontScale); height: scol.implicitHeight + Style.spacing.lg * 2
                 color: hover.containsMouse ? Util.alpha(tone, 0.16) : Util.alpha(tone, 0.08)
                 border.color: Util.alpha(tone, hover.containsMouse ? 0.9 : 0.45); border.width: 1; radius: view.radius
@@ -148,7 +150,7 @@ Item {
                   }
                   Text { Layout.fillWidth: true; text: sc.modelData.project || "/"; color: view.desk.themeForeground; font.family: view.mono; font.pixelSize: Style.font.subtitle; elide: Text.ElideMiddle }
                   Text { Layout.fillWidth: true; text: sc.modelData.cwd || ""; color: view.textFaint; font.family: view.mono; font.pixelSize: Style.font.caption; elide: Text.ElideMiddle }
-                  Text { Layout.fillWidth: true; visible: !!sc.modelData.window; text: sc.modelData.window ? (sc.modelData.window.title || "") : ""; color: view.textDim; font.family: view.mono; font.pixelSize: Style.font.caption; elide: Text.ElideRight }
+                  Text { Layout.fillWidth: true; visible: !!(sc.modelData.window && sc.modelData.window.title); text: sc.modelData.window ? (sc.modelData.window.title || "") : ""; color: view.textDim; font.family: view.mono; font.pixelSize: Style.font.caption; elide: Text.ElideRight }
                   Text { Layout.fillWidth: true; text: "pid " + sc.modelData.pid + (sc.modelData.window ? "  ·  ws " + sc.modelData.window.workspace : "  ·  no window"); color: view.textFaint; font.family: view.mono; font.pixelSize: Style.font.caption }
                 }
                 MouseArea {

--- a/collector.test.ts
+++ b/collector.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
 const historyFixture = join(import.meta.dir, ".test-fixture");
 afterAll(() => rmSync(historyFixture, { recursive: true, force: true }));
 import { join } from "path";
-import { providerOf } from "./collector.ts";
+import { providerOf, titleLooksBusy, cmdIsTurnInhibitor } from "./collector.ts";
 
 const fixture = join(import.meta.dir, ".test-fixture-races");
 afterAll(() => rmSync(fixture, { recursive: true, force: true }));
@@ -21,6 +21,22 @@ describe("providerOf", () => {
   test("ignores the Ollama daemon but keeps chats", () => {
     expect(providerOf(["ollama", "serve"])).toBeNull();
     expect(providerOf(["/usr/bin/ollama", "run", "llama3"])).toBe("ollama");
+  });
+});
+
+describe("busy detection", () => {
+  test("titleLooksBusy matches processing titles and not idle checkmarks", () => {
+    expect(titleLooksBusy("🧠 Processing request.")).toBe(true);
+    expect(titleLooksBusy("⚙️ Processing request.")).toBe(true);
+    expect(titleLooksBusy("✅ All five PRs checked")).toBe(false);
+    expect(titleLooksBusy("wallpaper.Larry")).toBe(false);
+  });
+
+  test("cmdIsTurnInhibitor matches Grok's idle-inhibit, not other inhibitors", () => {
+    expect(cmdIsTurnInhibitor(["systemd-inhibit", "--what=idle", "--who=grok", "--why=agent turn in progress", "sleep", "infinity"])).toBe(true);
+    expect(cmdIsTurnInhibitor(["/usr/bin/systemd-inhibit", "--what=idle", "--who=grok", "--why=agent turn in progress", "sleep", "infinity"])).toBe(true);
+    expect(cmdIsTurnInhibitor(["systemd-inhibit", "--what=sleep", "--who=Omarchy", "--why=Lock screen before suspend"])).toBe(false);
+    expect(cmdIsTurnInhibitor(["grok", "--yolo"])).toBe(false);
   });
 });
 

--- a/collector.ts
+++ b/collector.ts
@@ -194,6 +194,17 @@ export function providerOf(cmd: string[]): string | null {
   }
   return null;
 }
+// Claude/Codex retitle the terminal on idle (✅ …). Grok leaves
+// "🧠 Processing request." stuck after the turn, so title-based busy
+// is a lie. Grok's real signal is systemd-inhibit "agent turn in progress".
+export function titleLooksBusy(title: string): boolean {
+  return /Processing|🧠|⚙|⏳|…/.test(String(title || ""));
+}
+export function cmdIsTurnInhibitor(cmd: string[]): boolean {
+  const bin = cmd[0] || "";
+  if (!/(^|\/)systemd-inhibit$/.test(bin)) return false;
+  return cmd.some(a => /agent turn in progress/i.test(a));
+}
 function shortPath(p: string) { return p.startsWith(HOME) ? "~" + p.slice(HOME.length) : p; }
 
 async function liveSessions(pids: number[]) {
@@ -217,6 +228,23 @@ async function liveSessions(pids: number[]) {
       window: w ? { address: w.address, title: w.title, class: w.class, workspace: w.workspace?.id ?? null } : null,
       args: p.cmd.slice(1, 4).join(" ").slice(0, 60),
     });
+  }
+  const sessionPids = new Set(sessions.map((s: any) => s.pid as number));
+  const turnBusy = new Set<number>();
+  for (const pid of pids) {
+    if (!cmdIsTurnInhibitor(cmdByPid.get(pid) || [])) continue;
+    let q = info(pid);
+    while (q && q.pid > 1) {
+      if (sessionPids.has(q.pid)) { turnBusy.add(q.pid); break; }
+      q = info(q.ppid);
+    }
+  }
+  for (const s of sessions) {
+    const titleBusy = !!(s.window && titleLooksBusy(s.window.title));
+    // Grok's terminal title sticks on 🧠 after the turn. Trust the inhibitor.
+    s.busy = s.provider === "grok" ? turnBusy.has(s.pid) : (titleBusy || turnBusy.has(s.pid));
+    if (!s.busy && s.window && titleLooksBusy(s.window.title) && s.provider === "grok")
+      s.window = { ...s.window, title: "" };
   }
   sessions.sort((a, b) => b.startedAt - a.startedAt);
   return sessions;


### PR DESCRIPTION
## Why

The live-session busy-dot is a title regex:

```
/Processing|🧠|⚙|⏳|…/
```

Claude and Codex retitle to `✅ …` when idle. **Grok does not.** It sets the kitty title to `🧠 Processing request.` at the start of a turn and leaves it there.

Observed on vic just now:

| session | title | `systemd-inhibit --why=agent turn in progress` | card |
|---|---|---|---|
| grok @ wallpaper.Larry | 🧠 Processing request. | yes (this turn) | should pulse |
| grok @ plonk | 🧠 Processing request. | **no** | was pulsing anyway |

## What

- Grok `busy` = a descendant `systemd-inhibit --why=agent turn in progress` whose parent chain hits the session pid
- Claude/Codex still use the title (accurate) plus the same inhibitor if present
- Idle Grok snapshots **blank** the stuck processing title so an already-loaded InfoView (old regex) stops pulsing on the next 4s collector tick — no shell restart required
- `session.busy` is now in the snapshot; InfoView prefers it

## Test plan

- [x] `bun test collector.test.ts` (7 pass)
- [x] Live snapshot: idle plonk grok `busy=false` title=`""`; this-turn wallpaper grok `busy=true` title kept
- [ ] After merge: idle Grok card does not pulse; pulsing resumes on the next prompt and stops when the reply finishes