### PR TITLE
Add AI operations desk and privacy mode

### DIFF
--- a/InfoView.qml
+++ b/InfoView.qml
@@ -11,6 +11,7 @@ Item {
   id: view
   required property InfoModel desk
   property bool interactive: true
+  property bool privacyMode: false
   // Room for the bar. The background layer ignores exclusion zones on purpose,
   // so we leave a top strip free instead of drawing under the bar.
   property int topInset: Math.round(40 * Style.fontScale)
@@ -19,6 +20,8 @@ Item {
   readonly property var machine: snap.machine || ({})
   readonly property var ai: snap.ai || ({})
   readonly property var sessions: ai.sessions || []
+  readonly property var attention: ai.attention || []
+  readonly property var collisions: ai.collisions || []
   readonly property var usage: (ai && ai.usage) ? ai.usage : ({})
   readonly property int pad: Style.spacing.xl
   readonly property int gap: Style.spacing.lg
@@ -113,11 +116,35 @@ Item {
         Layout.preferredWidth: 3
         spacing: view.gap
 
+        Card {
+          Layout.fillWidth: true
+          visible: view.attention.length > 0 || view.collisions.length > 0 || view.privacyMode
+          title: "NEEDS YOU"
+          hint: view.privacyMode ? "PRIVACY MODE · sensitive details hidden" : view.attention.length + " signals · " + view.collisions.length + " shared repos"
+          Flow {
+            width: parent.width
+            spacing: Style.spacing.md
+            Repeater {
+              model: view.attention
+              delegate: Tag {
+                required property var modelData
+                text: (modelData.attention === "blocked" ? "⚠ BLOCKED" : modelData.attention === "waiting" ? "? WAITING" : "✓ REVIEW") + " · " + view.desk.providerLabel(modelData.provider) + " · " + (view.privacyMode ? "private" : modelData.project)
+                tone: modelData.attention === "blocked" ? view.desk.red : modelData.attention === "waiting" ? view.desk.yellow : view.desk.green
+              }
+            }
+            Repeater {
+              model: view.collisions
+              delegate: Tag { required property var modelData; text: "⚠ SHARED REPO · " + (view.privacyMode ? "private" : modelData.project) + " · " + modelData.agents.length + " agents"; tone: view.desk.yellow }
+            }
+            Tag { visible: view.privacyMode && view.attention.length === 0 && view.collisions.length === 0; text: "PRIVACY ON"; tone: view.desk.cyan }
+          }
+        }
+
         // ---- live sessions ----
         Card {
           Layout.fillWidth: true
           title: "LIVE AI SESSIONS"
-          hint: view.sessions.length + " running · " + (view.snap.host || "") + (view.desk.error ? " · ⚠ " + view.desk.error : "")
+          hint: view.sessions.length + " running · " + (view.privacyMode ? "private host" : (view.snap.host || "")) + (view.desk.error ? " · ⚠ " + view.desk.error : "")
           Flow {
             width: parent.width
             spacing: Style.spacing.md
@@ -148,9 +175,10 @@ Item {
                     Item { Layout.fillWidth: true }
                     Text { text: view.desk.dur(sc.modelData.uptimeSec); color: view.textFaint; font.family: view.mono; font.pixelSize: Style.font.caption }
                   }
-                  Text { Layout.fillWidth: true; text: sc.modelData.project || "/"; color: view.desk.themeForeground; font.family: view.mono; font.pixelSize: Style.font.subtitle; elide: Text.ElideMiddle }
-                  Text { Layout.fillWidth: true; text: sc.modelData.cwd || ""; color: view.textFaint; font.family: view.mono; font.pixelSize: Style.font.caption; elide: Text.ElideMiddle }
-                  Text { Layout.fillWidth: true; visible: !!(sc.modelData.window && sc.modelData.window.title); text: sc.modelData.window ? (sc.modelData.window.title || "") : ""; color: view.textDim; font.family: view.mono; font.pixelSize: Style.font.caption; elide: Text.ElideRight }
+                  Text { Layout.fillWidth: true; text: view.privacyMode ? "private project" : (sc.modelData.project || "/"); color: view.desk.themeForeground; font.family: view.mono; font.pixelSize: Style.font.subtitle; elide: Text.ElideMiddle }
+                  Text { Layout.fillWidth: true; text: view.privacyMode ? "path hidden" : (sc.modelData.cwd || ""); color: view.textFaint; font.family: view.mono; font.pixelSize: Style.font.caption; elide: Text.ElideMiddle }
+                  Text { Layout.fillWidth: true; visible: !!(sc.modelData.window && sc.modelData.window.title); text: view.privacyMode ? "task hidden" : (sc.modelData.window ? (sc.modelData.window.title || "") : ""); color: view.textDim; font.family: view.mono; font.pixelSize: Style.font.caption; elide: Text.ElideRight }
+                  Text { Layout.fillWidth: true; visible: !!sc.modelData.git; text: sc.modelData.git ? ("git " + sc.modelData.git.branch + (sc.modelData.git.dirty ? " · " + sc.modelData.git.dirty + " changed" : " · clean") + (sc.modelData.git.ahead ? " · ↑" + sc.modelData.git.ahead : "") + (sc.modelData.git.behind ? " · ↓" + sc.modelData.git.behind : "") + (sc.modelData.git.conflicts ? " · " + sc.modelData.git.conflicts + " conflicts" : "")) : ""; color: sc.modelData.git && sc.modelData.git.conflicts ? view.desk.red : sc.modelData.git && sc.modelData.git.dirty ? view.desk.yellow : view.desk.green; font.family: view.mono; font.pixelSize: Style.font.caption; elide: Text.ElideRight }
                   Text { Layout.fillWidth: true; text: "pid " + sc.modelData.pid + (sc.modelData.window ? "  ·  ws " + sc.modelData.window.workspace : "  ·  no window"); color: view.textFaint; font.family: view.mono; font.pixelSize: Style.font.caption }
                 }
                 MouseArea {
@@ -275,7 +303,7 @@ Item {
           Layout.fillWidth: true
           Layout.fillHeight: true
           title: "RECENT TASKS · WHAT GOT ASKED"
-          hint: "newest first"
+          hint: view.privacyMode ? "hidden · press P in overlay to reveal" : "newest first"
           clip: true
           ListView {
             id: recentList
@@ -294,8 +322,8 @@ Item {
                 id: rrow; width: parent.width; spacing: Style.spacing.md
                 Text { text: view.desk.ago(ri.modelData.ts); color: view.textFaint; font.family: view.mono; font.pixelSize: Style.font.caption; Layout.preferredWidth: Math.round(28 * Style.fontScale); horizontalAlignment: Text.AlignRight }
                 Tag { text: view.desk.providerLabel(ri.modelData.provider); tone: view.desk.providerColor(ri.modelData.provider) }
-                Text { text: (ri.modelData.project || "").replace(/^.*\//, "") ; color: view.textDim; font.family: view.mono; font.pixelSize: Style.font.caption; Layout.preferredWidth: Math.round(110 * Style.fontScale); elide: Text.ElideLeft }
-                Text { Layout.fillWidth: true; text: ri.modelData.text || ""; color: view.desk.themeForeground; font.family: view.mono; font.pixelSize: Style.font.bodySmall; elide: Text.ElideRight; maximumLineCount: 1 }
+                Text { text: view.privacyMode ? "private" : (ri.modelData.project || "").replace(/^.*\//, "") ; color: view.textDim; font.family: view.mono; font.pixelSize: Style.font.caption; Layout.preferredWidth: Math.round(110 * Style.fontScale); elide: Text.ElideLeft }
+                Text { Layout.fillWidth: true; text: view.privacyMode ? "prompt hidden" : (ri.modelData.text || ""); color: view.desk.themeForeground; font.family: view.mono; font.pixelSize: Style.font.bodySmall; elide: Text.ElideRight; maximumLineCount: 1 }
               }
             }
           }
@@ -399,7 +427,7 @@ Item {
         Card {
           Layout.fillWidth: true
           title: "MACHINE"
-          hint: (view.snap.user ? view.snap.user + "@" : "") + (view.snap.host || "") + " · up " + view.desk.dur(view.machine.uptime)
+          hint: (view.privacyMode ? "private host" : ((view.snap.user ? view.snap.user + "@" : "") + (view.snap.host || ""))) + " · up " + view.desk.dur(view.machine.uptime)
           readonly property var net: view.machine.net || ({})
           readonly property var mem: view.machine.mem || ({})
           readonly property var cpu: view.machine.cpu || ({})
@@ -418,8 +446,8 @@ Item {
             }
             Meter {
               Layout.fillWidth: true
-              label: mc.net.wireless ? "WIFI " + (mc.net.ssid || "") : "NET " + (mc.net.dev || "—")
-              value: (mc.net.signal !== null && mc.net.signal !== undefined ? mc.net.signal + " dBm · " : "") + (mc.net.addr || "")
+              label: mc.net.wireless ? "WIFI " + (view.privacyMode ? "private" : (mc.net.ssid || "")) : "NET " + (mc.net.dev || "—")
+              value: (mc.net.signal !== null && mc.net.signal !== undefined ? mc.net.signal + " dBm" : "") + (view.privacyMode ? "" : " · " + (mc.net.addr || ""))
               // -30 dBm great … -90 dBm dead
               fraction: mc.net.signal !== null && mc.net.signal !== undefined ? Math.max(0, Math.min(1, (Number(mc.net.signal) + 90) / 60)) : (mc.net.dev ? 1 : 0)
               tone: mc.net.signal !== null && mc.net.signal !== undefined && Number(mc.net.signal) < -75 ? view.desk.yellow : view.desk.green

--- a/Infomarchy.qml
+++ b/Infomarchy.qml
@@ -22,6 +22,7 @@ Scope {
   property string background: ""
   // How much of the wallpaper survives under the glass. 0 = solid theme bg.
   property real wallpaperOpacity: 0.32
+  property bool privacyMode: false
 
   InfoModel { id: infoModel; refreshMs: 4000 }
 
@@ -72,6 +73,8 @@ Scope {
     target: "infomarchy"
     function refresh(): void { infoModel.refresh() }
     function setWallpaperOpacity(v: string): void { var n = Number(v); if (isFinite(n)) root.wallpaperOpacity = Math.max(0, Math.min(1, n)) }
+    function setPrivacy(v: string): void { root.privacyMode = ["1", "true", "on", "yes"].indexOf(String(v).toLowerCase()) >= 0 }
+    function togglePrivacy(): void { root.privacyMode = !root.privacyMode }
   }
 
   Variants {
@@ -118,6 +121,7 @@ Scope {
         anchors.fill: parent
         desk: infoModel
         interactive: true
+        privacyMode: root.privacyMode
       }
     }
   }

--- a/Overlay.qml
+++ b/Overlay.qml
@@ -11,6 +11,7 @@ import qs.Ui
 Scope {
   id: root
   property bool opened: false
+  property bool privacyMode: false
 
   InfoModel { id: infoModel; refreshMs: 3000; active: root.opened; instance: "overlay" }
 
@@ -49,6 +50,7 @@ Scope {
         color: Util.alpha(infoModel.themeBackground, 0.88)
         focus: root.opened
         Keys.onEscapePressed: root.close()
+        Keys.onPressed: function(event) { if (event.key === Qt.Key_P && !(event.modifiers & Qt.ControlModifier)) { root.privacyMode = !root.privacyMode; event.accepted = true } }
         // Exclusive keyboard focus on the layer is not enough — Qt still
         // needs an item with activeFocus or Esc never fires.
         onVisibleChanged: if (visible) Qt.callLater(function() { keyCatcher.forceActiveFocus() })
@@ -58,6 +60,7 @@ Scope {
           desk: infoModel
           interactive: true
           topInset: Style.spacing.xl
+          privacyMode: root.privacyMode
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Infomarchy puts all of it on the one surface you always have open and never use:
 
 One card per running agent — **Claude Code, Codex, Grok, Gemini, opencode, aider, Ollama chats** — detected straight from `/proc`, no agent-side hooks, nothing to configure. Each card shows the project, working directory, how long it's been up, the pid, the workspace it lives on, and the terminal's own title (so you read *"✅ Researched virt-manager plugins"* or *"⚙️ Processing request."* without switching to it). The dot **pulses while the agent is thinking**.
 
+Cards also show the repository branch, clean/changed state, ahead/behind counts, and merge conflicts. A **Needs You** strip calls out agents that appear blocked, waiting for input, or finished for review, plus repositories being shared by multiple live agents.
+
 **Click a card → Infomarchy focuses the terminal window hosting that agent.** It walks the process tree up to the Hyprland client, so it works through `kitty`, `alacritty`, `ghostty`, tmux, whatever.
 
 </td>
@@ -164,19 +166,22 @@ No usernames, hostnames or absolute paths are hardcoded anywhere. The collector 
 omarchy-shell infomarchy refresh                                      # wallpaper collector now
 omarchy-shell shell call nixfred.infomarchy refresh                   # overlay collector (only while summoned)
 omarchy-shell infomarchy setWallpaperOpacity 0.5                      # 0 = solid theme bg
+omarchy-shell infomarchy togglePrivacy                                # hide/reveal sensitive wallpaper details
+omarchy-shell infomarchy setPrivacy true                              # explicit on/off control
 ```
 
 | Knob | Where | Default |
 |---|---|---|
 | poll interval | `refreshMs` in `Infomarchy.qml` / `Overlay.qml` | 4000 / 3000 ms |
 | wallpaper dim | `wallpaperOpacity` in `Infomarchy.qml` | 0.32 |
+| privacy mode | `P` while the overlay is open, or wallpaper IPC above | off |
 | space left for the bar | `topInset` in `InfoView.qml` | 40 px × font scale |
 | provider colours | `providerColor()` in `InfoModel.qml` | theme ANSI roles |
 | add a provider | one regex in `PROVIDERS` in `collector.ts` | — |
 
 ## Privacy
 
-Everything stays on the machine — there is no network call except the ping to `1.1.1.1` and the local Ollama API. The **Recent tasks** card shows the text of your own recent prompts on your own desktop; if you screen-share, summon something over it or comment out that card in `InfoView.qml`.
+Everything stays on the machine — there is no network call except the ping to `1.1.1.1` and the local Ollama API. Recent task text is credential-redacted before it reaches QML. **Privacy mode** additionally hides prompts, project names, paths, terminal titles, username/hostname, SSID, and IP address; press `P` in the fullscreen overlay or use the wallpaper IPC commands above before screen sharing.
 
 ## FAQ
 

--- a/ai-ops.test.ts
+++ b/ai-ops.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { attentionState, parseGitStatus, repoCollisions } from "./ai-ops";
+
+describe("AI operations signals", () => {
+  test("parses branch readiness and conflicts", () => {
+    const state = parseGitStatus("# branch.head feature\n# branch.upstream origin/feature\n# branch.ab +2 -1\n1 .M N... 100644 100644 100644 a b file\nu UU N... 100644 100644 100644 100644 a b c file2\n");
+    expect(state).toEqual({ branch: "feature", upstream: "origin/feature", ahead: 2, behind: 1, dirty: 2, conflicts: 1 });
+  });
+
+  test("prioritizes blocked, waiting, and completed titles", () => {
+    expect(attentionState("Permission required to continue")).toBe("waiting");
+    expect(attentionState("✅ Ready for review")).toBe("done");
+    expect(attentionState("working", 1)).toBe("blocked");
+  });
+
+  test("reports agents sharing a repository", () => {
+    const collisions = repoCollisions([
+      { repoRoot: "/work/a", project: "a", provider: "claude", pid: 1 },
+      { repoRoot: "/work/a", project: "a", provider: "codex", pid: 2 },
+      { repoRoot: "/work/b", project: "b", provider: "grok", pid: 3 },
+    ]);
+    expect(collisions).toHaveLength(1);
+    expect(collisions[0].agents).toHaveLength(2);
+  });
+});

--- a/ai-ops.ts
+++ b/ai-ops.ts
@@ -1,0 +1,45 @@
+export type RepoState = {
+  branch: string;
+  upstream: string;
+  ahead: number;
+  behind: number;
+  dirty: number;
+  conflicts: number;
+};
+
+export function parseGitStatus(text: string): RepoState | null {
+  if (!text.trim()) return null;
+  const state: RepoState = { branch: "", upstream: "", ahead: 0, behind: 0, dirty: 0, conflicts: 0 };
+  for (const line of text.split("\n")) {
+    if (line.startsWith("# branch.head ")) state.branch = line.slice(14).trim();
+    else if (line.startsWith("# branch.upstream ")) state.upstream = line.slice(18).trim();
+    else if (line.startsWith("# branch.ab ")) {
+      const match = line.match(/\+(\d+)\s+-(\d+)/);
+      if (match) { state.ahead = +match[1]; state.behind = +match[2]; }
+    } else if (/^[12?] /.test(line)) state.dirty++;
+    else if (/^u /.test(line)) { state.dirty++; state.conflicts++; }
+  }
+  return state.branch || state.dirty ? state : null;
+}
+
+export function attentionState(title: unknown, conflicts = 0): "blocked" | "waiting" | "done" | "" {
+  const value = String(title || "");
+  if (conflicts > 0 || /\b(error|failed|blocked|conflict|denied|crashed)\b/i.test(value)) return "blocked";
+  if (/\b(waiting|permission|approve|approval|confirm|input required|needs input)\b/i.test(value)) return "waiting";
+  if (/✅|\b(done|complete|completed|finished|ready for review)\b/i.test(value)) return "done";
+  return "";
+}
+
+export function repoCollisions(sessions: any[]): any[] {
+  const byRoot = new Map<string, any[]>();
+  for (const session of sessions) {
+    if (!session.repoRoot) continue;
+    const group = byRoot.get(session.repoRoot) || [];
+    group.push(session); byRoot.set(session.repoRoot, group);
+  }
+  return [...byRoot.entries()].filter(([, group]) => group.length > 1).map(([repo, group]) => ({
+    repo,
+    project: group[0].project,
+    agents: group.map(s => ({ provider: s.provider, pid: s.pid })),
+  }));
+}

--- a/collector.ts
+++ b/collector.ts
@@ -7,6 +7,7 @@
 import { readdirSync, readFileSync, statSync, existsSync, readlinkSync, mkdirSync, writeFileSync } from "fs";
 import { join, basename } from "path";
 import { localDayIndex, localDayStarts } from "./history-time";
+import { attentionState, parseGitStatus, repoCollisions } from "./ai-ops";
 
 const HOME = process.env.HOME || "/root";
 const XDG_STATE = process.env.XDG_STATE_HOME || join(HOME, ".local/state");
@@ -207,6 +208,15 @@ export function cmdIsTurnInhibitor(cmd: string[]): boolean {
 }
 function shortPath(p: string) { return p.startsWith(HOME) ? "~" + p.slice(HOME.length) : p; }
 
+async function repoState(cwd: string) {
+  if (!cwd) return { root: "", state: null };
+  const [root, status] = await Promise.all([
+    run(["git", "-C", cwd, "rev-parse", "--show-toplevel"], 700),
+    run(["git", "-C", cwd, "status", "--porcelain=v2", "--branch"], 900),
+  ]);
+  return { root: root.trim(), state: parseGitStatus(status) };
+}
+
 async function liveSessions(pids: number[]) {
   let clients: any[] = [];
   try { clients = JSON.parse(await run(["hyprctl", "clients", "-j"], 1000)) || []; } catch {}
@@ -224,6 +234,7 @@ async function liveSessions(pids: number[]) {
     while (q && q.pid > 1) { if (winByPid.has(q.pid)) { w = winByPid.get(q.pid); break; } q = info(q.ppid); }
     sessions.push({
       provider: prov, pid: p.pid, cwd: shortPath(p.cwd), project: basename(p.cwd || "") || "/",
+      _cwd: p.cwd,
       startedAt: p.start, uptimeSec: Math.max(0, (now - p.start) / 1000),
       window: w ? { address: w.address, title: w.title, class: w.class, workspace: w.workspace?.id ?? null } : null,
       args: p.cmd.slice(1, 4).join(" ").slice(0, 60),
@@ -246,6 +257,15 @@ async function liveSessions(pids: number[]) {
     if (!s.busy && s.window && titleLooksBusy(s.window.title) && s.provider === "grok")
       s.window = { ...s.window, title: "" };
   }
+  const repos = new Map<string, Promise<{ root: string; state: any }>>();
+  for (const session of sessions) if (session._cwd && !repos.has(session._cwd)) repos.set(session._cwd, repoState(session._cwd));
+  await Promise.all(sessions.map(async session => {
+    const repo = session._cwd ? await repos.get(session._cwd) : null;
+    session.repoRoot = repo?.root ? shortPath(repo.root) : "";
+    session.git = repo?.state || null;
+    session.attention = attentionState(session.window?.title, session.git?.conflicts || 0);
+    delete session._cwd;
+  }));
   sessions.sort((a, b) => b.startedAt - a.startedAt);
   return sessions;
 }
@@ -386,7 +406,10 @@ async function runCollector() {
       battery: battery(), gpu: gpuS, temp: temp(), uptime: uptime(),
     },
     ai: {
-      sessions, counts, providers: { claude, codex, grok, ollama }, usage: agentsUsage(),
+      sessions,
+      attention: sessions.filter((s: any) => s.attention),
+      collisions: repoCollisions(sessions),
+      counts, providers: { claude, codex, grok, ollama }, usage: agentsUsage(),
       heatmap: { start: start7, days: heatDays, cells: heat.map(c => [c.n, c.p]) }, recent: recent.slice(0, 40),
     },
   };


### PR DESCRIPTION
## Summary
- add a Needs You strip for blocked, waiting, and completed-for-review sessions
- show per-session Git branch, dirty/clean state, ahead/behind counts, and conflicts
- warn when multiple live agents share the same repository
- add privacy mode masking prompts, projects, paths, terminal titles, host identity, SSID, and IP
- toggle overlay privacy with `P`; control wallpaper privacy through IPC
- document the new signals and controls

## Verification
- `bun test` (12 passing)
- `bun --check collector.ts`
- live collector snapshot verified Git, attention, and collision shapes
- `git diff --check`

## Notes
Attention state is intentionally conservative and inferred from terminal titles plus Git conflicts. Repository checks are local-only and deduplicated per working directory.