### PR TITLE
Make Needs You alerts navigate to agents

### DIFF
--- a/InfoView.qml
+++ b/InfoView.qml
@@ -12,6 +12,13 @@ Item {
   required property InfoModel desk
   property bool interactive: true
   property bool privacyMode: false
+  signal navigated()
+
+  function navigateTo(address) {
+    if (!address) return
+    view.desk.focusWindow(address)
+    view.navigated()
+  }
   // Room for the bar. The background layer ignores exclusion zones on purpose,
   // so we leave a top strip free instead of drawing under the bar.
   property int topInset: Math.round(40 * Style.fontScale)
@@ -130,6 +137,12 @@ Item {
                 required property var modelData
                 text: (modelData.attention === "blocked" ? "⚠ BLOCKED" : modelData.attention === "waiting" ? "? WAITING" : "✓ REVIEW") + " · " + view.desk.providerLabel(modelData.provider) + " · " + (view.privacyMode ? "private" : modelData.project)
                 tone: modelData.attention === "blocked" ? view.desk.red : modelData.attention === "waiting" ? view.desk.yellow : view.desk.green
+                MouseArea {
+                  anchors.fill: parent
+                  enabled: view.interactive && !!(parent.modelData.window && parent.modelData.window.address)
+                  cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                  onClicked: view.navigateTo(parent.modelData.window.address)
+                }
               }
             }
             Repeater {
@@ -185,7 +198,7 @@ Item {
                   id: hover; anchors.fill: parent; hoverEnabled: true; enabled: view.interactive
                   cursorShape: sc.modelData.window ? Qt.PointingHandCursor : Qt.ArrowCursor
                   acceptedButtons: Qt.LeftButton
-                  onClicked: if (sc.modelData.window) view.desk.focusWindow(sc.modelData.window.address)
+                  onClicked: if (sc.modelData.window) view.navigateTo(sc.modelData.window.address)
                 }
               }
             }

--- a/Overlay.qml
+++ b/Overlay.qml
@@ -61,6 +61,7 @@ Scope {
           interactive: true
           topInset: Style.spacing.xl
           privacyMode: root.privacyMode
+          onNavigated: root.close()
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ One card per running agent — **Claude Code, Codex, Grok, Gemini, opencode, aid
 
 Cards also show the repository branch, clean/changed state, ahead/behind counts, and merge conflicts. A **Needs You** strip calls out agents that appear blocked, waiting for input, or finished for review, plus repositories being shared by multiple live agents.
 
+**Click a Needs You signal → jump straight to that agent's terminal.** From the fullscreen overlay, Infomarchy closes itself after focusing the session.
+
 **Click a card → Infomarchy focuses the terminal window hosting that agent.** It walks the process tree up to the Hyprland client, so it works through `kitty`, `alacritty`, `ghostty`, tmux, whatever.
 
 </td>


### PR DESCRIPTION
## Summary
- make each actionable Needs You chip focus its agent terminal
- route ordinary session-card navigation through the same path
- dismiss the fullscreen overlay after navigation so the target is visible
- show a pointer cursor only when a target window is available
- document the click-through behavior

## Verification
- `bun test` (12 passing)
- `bun --check collector.ts`
- `git diff --check`