### PR TITLE
Add SUPER+I wallpaper dashboard toggle

### DIFF
--- a/Infomarchy.qml
+++ b/Infomarchy.qml
@@ -23,6 +23,7 @@ Scope {
   // How much of the wallpaper survives under the glass. 0 = solid theme bg.
   property real wallpaperOpacity: 0.32
   property bool privacyMode: false
+  property bool dashboardVisible: true
 
   InfoModel { id: infoModel; refreshMs: 4000 }
 
@@ -75,6 +76,8 @@ Scope {
     function setWallpaperOpacity(v: string): void { var n = Number(v); if (isFinite(n)) root.wallpaperOpacity = Math.max(0, Math.min(1, n)) }
     function setPrivacy(v: string): void { root.privacyMode = ["1", "true", "on", "yes"].indexOf(String(v).toLowerCase()) >= 0 }
     function togglePrivacy(): void { root.privacyMode = !root.privacyMode }
+    function setDashboardVisible(v: string): void { root.dashboardVisible = ["1", "true", "on", "yes"].indexOf(String(v).toLowerCase()) >= 0 }
+    function toggleDashboard(): void { root.dashboardVisible = !root.dashboardVisible }
   }
 
   Variants {
@@ -122,6 +125,7 @@ Scope {
         desk: infoModel
         interactive: true
         privacyMode: root.privacyMode
+        visible: root.dashboardVisible
       }
     }
   }

--- a/Infomarchy.qml
+++ b/Infomarchy.qml
@@ -113,11 +113,21 @@ Scope {
         Behavior on opacity { NumberAnimation { duration: 300 } }
       }
 
-      // Right-click on empty desk = wallpaper switcher, like stock Omarchy.
+      // Empty-desk gestures: left double-click = wallpaper switcher (stock
+      // omarchy.background behavior, restored 2026-08-22), right single-click =
+      // wallpaper switcher (Infomarchy addition). Stock's right-double-click
+      // theme switcher is intentionally not mirrored: it would race the
+      // right single-click and open two menus.
       MouseArea {
         anchors.fill: parent
-        acceptedButtons: Qt.RightButton
-        onClicked: if (!bgSwitchProc.running) bgSwitchProc.running = true
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        onClicked: function(mouse) {
+          if (mouse.button === Qt.RightButton && !bgSwitchProc.running) bgSwitchProc.running = true
+        }
+        onDoubleClicked: function(mouse) {
+          if (mouse.button === Qt.LeftButton && !bgSwitchProc.running) bgSwitchProc.running = true
+          mouse.accepted = true
+        }
       }
 
       InfoView {

--- a/README.md
+++ b/README.md
@@ -102,10 +102,11 @@ omarchy-restart-shell    # first time only: services load at shell start
 
 The plugin declares itself as a clone of `omarchy.background`, so Omarchy hands it the wallpaper role. Your chosen wallpaper is still there — dimmed to 32% behind the glass — and `omarchy theme bg set …` keeps working.
 
-Bind the overlay in `~/.config/hypr/bindings.lua` (pick any free chord):
+Bind the fullscreen overlay and wallpaper-dashboard toggle in `~/.config/hypr/bindings.lua` (pick any free chords):
 
 ```lua
 o.bind("SUPER + D", "Infomarchy: AI info desk", "omarchy-shell shell toggle nixfred.infomarchy '{}'")
+o.bind("SUPER + I", "Infomarchy: toggle wallpaper dashboard", "omarchy-shell infomarchy toggleDashboard")
 ```
 
 <details>
@@ -170,6 +171,8 @@ omarchy-shell shell call nixfred.infomarchy refresh                   # overlay 
 omarchy-shell infomarchy setWallpaperOpacity 0.5                      # 0 = solid theme bg
 omarchy-shell infomarchy togglePrivacy                                # hide/reveal sensitive wallpaper details
 omarchy-shell infomarchy setPrivacy true                              # explicit on/off control
+omarchy-shell infomarchy toggleDashboard                              # hide/show cards; keep wallpaper
+omarchy-shell infomarchy setDashboardVisible true                     # explicit on/off control
 ```
 
 | Knob | Where | Default |
@@ -177,6 +180,7 @@ omarchy-shell infomarchy setPrivacy true                              # explicit
 | poll interval | `refreshMs` in `Infomarchy.qml` / `Overlay.qml` | 4000 / 3000 ms |
 | wallpaper dim | `wallpaperOpacity` in `Infomarchy.qml` | 0.32 |
 | privacy mode | `P` while the overlay is open, or wallpaper IPC above | off |
+| wallpaper dashboard | `SUPER+I` or wallpaper IPC above | visible |
 | space left for the bar | `topInset` in `InfoView.qml` | 40 px × font scale |
 | provider colours | `providerColor()` in `InfoModel.qml` | theme ANSI roles |
 | add a provider | one regex in `PROVIDERS` in `collector.ts` | — |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Any meter goes **red** when it's genuinely in trouble (RAM > 90%, disk > 90%, CP
 
 ### ⌨️ Two surfaces, one dashboard
 
-The wallpaper is interactive wherever no window covers it (right-click the empty desk still opens Omarchy's wallpaper switcher). When you're buried in terminals, **`SUPER + D`** summons the *same* dashboard as a fullscreen overlay on top of everything; `Esc` or a click on the backdrop dismisses it.
+The wallpaper is interactive wherever no window covers it (double-click or right-click the empty desk opens Omarchy's wallpaper switcher, as stock does). When you're buried in terminals, **`SUPER + D`** summons the *same* dashboard as a fullscreen overlay on top of everything; `Esc` or a click on the backdrop dismisses it.
 
 ## Install
 


### PR DESCRIPTION
## Summary
- add IPC methods to hide/show only the wallpaper information dashboard
- keep the wallpaper, background plugin, and SUPER+D overlay active while hidden
- document SUPER+I and direct IPC controls

## Verification
- `bun test` (12 passing)
- `bun --check collector.ts`
- `git diff --check`
- verified SUPER+I was unbound before use
- `hyprctl reload` and `hyprctl configerrors` clean
- live Hyprland bind reports SUPER+I → Infomarchy toggle