### PR TITLE
fix: recognize Hermes launched via python -m hermes_cli.main

### DIFF
--- a/collector.test.ts
+++ b/collector.test.ts
@@ -77,6 +77,20 @@ describe("providerOf", () => {
     expect(providerOf(["/home/user/.hermes/bin/hermes"])).toBe("hermes");
   });
 
+  test("recognizes Hermes launched via the -m hermes_cli.main module form", () => {
+    // A bare module form or one with an interactive flag is a live session
+    // (this is how optional shebang-less installs actually launch). It was
+    // invisible before the hermes_cli.main pattern was added.
+    expect(providerOf(["/home/j_kro/.hermes/hermes-agent/venv/bin/python", "-m", "hermes_cli.main", "--yolo"])).toBe("hermes");
+    expect(providerOf(["/home/j_kro/.hermes/hermes-agent/venv/bin/python", "-m", "hermes_cli.main", "chat"])).toBe("hermes");
+  });
+
+  test("keeps Hermes daemons and service subcommands off the desk", () => {
+    expect(providerOf(["/home/j_kro/.hermes/hermes-agent/venv/bin/python", "-m", "hermes_cli.main", "gateway", "run"])).toBeNull();
+    expect(providerOf(["/home/j_kro/.hermes/hermes-agent/venv/bin/python", "-m", "hermes_cli.main", "proxy", "start", "--provider", "nous"])).toBeNull();
+    expect(providerOf(["python", "-m", "hermes_cli.main", "cron", "list"])).toBeNull();
+  });
+
   test("recognizes Muse however mise resolved it", () => {
     // Muse installs as a shell launcher on PATH that execs the real CLI out of
     // a mise install directory, so the process can present either path.

--- a/collector.ts
+++ b/collector.ts
@@ -551,7 +551,7 @@ const PROVIDERS: [string, RegExp][] = [
   ["grok", /(^|\/)grok(\.js|\.mjs)?$/],
   ["grok-bot", /(^|\/)grok-bot(\s|$)/],
   ["gemini", /(^|\/)gemini(\.js|\.mjs)?$/],
-  ["hermes", /(^|\/)hermes(\.js|\.mjs|\.py)?$/],
+  ["hermes", /(^|\/)(hermes|hermes_cli\.main)(\.js|\.mjs|\.py)?$/],
   // Muse ships as a mise-managed launcher (~/.local/bin/muse) that execs the
   // real CLI, so the process on the desk answers to plain "muse" either way.
   ["muse", /(^|\/)muse$/],
@@ -578,6 +578,17 @@ export function providerOf(cmd: string[]): string | null {
       // `claude daemon run` is Claude Code's background-session supervisor. It
       // showed up as a card ("Improving Pi", cwd ~) with nothing to click.
       if (name === "claude" && cmd[1] === "daemon") return null;
+      // Hermes launched via `python -m hermes_cli.main <subcommand>` runs a
+      // service/daemon (gateway, proxy, cron, send, ...), not a desk session —
+      // those must not become cards. A bare `hermes`, `hermes --yolo`, or the
+      // direct-script `.../hermes` (no subcommand) is a live interactive turn
+      // and counts. The -m module form puts the subcommand at argv[2] when the
+      // interpreter is argv[0] and "-m" is argv[1].
+      if (name === "hermes") {
+        const mod = cmd[0] && /(^|\/)(python[0-9.]*)$/.test(cmd[0]) && cmd[1] === "-m";
+        if (mod && /(^|\/)hermes_cli\.main$/.test(cmd[2] || "") && cmd[3]
+            && /^(gateway|proxy|cron|send|webhook|slack|whatsapp|whatsapp-cloud|peer|cron|sync|logs|dashboard|serve|desktop|mcp|peers)$/.test(cmd[3])) return null;
+      }
       // Grok Bot is Electron: the zygote/renderer/gpu/utility helpers all carry
       // the same argv[0] as the browser process, and the local-exec daemon runs
       // that binary against a script. Only the browser process owns the window


### PR DESCRIPTION
Two related changes for Hermes support on the Infomarchy desk:

## 1. Hermes session history (feat, 9014a85)
Adds a Hermes history source that reads `~/.hermes/state.db` (read-only,
bounded) and surfaces recent prompts in the Recent list, plus live Hermes
sessions in the sessions panel. Mirrors the existing opencode/claude history
sources. Includes tests.

## 2. Fix live Hermes detection when launched via `python -m hermes_cli.main` (9178ecf)
`providerOf()` only matched a hermes process whose launcher arg ends in
`/hermes`. On hosts where hermes is invoked through the interpreter form
`python -m hermes_cli.main` (optional shebang-less installs), the `--yolo`
interactive session arg is `hermes_cli.main`, which failed the regex — so
the live session was invisible and intermittently vanished from the desk.

Now `hermes_cli.main` module form matches, but daemon/service subcommands
(gateway, proxy, cron, send, ...) are excluded so only live interactive
turns become cards. Adds regression tests both ways.

Tested: `bun test collector.test.ts` → 88 pass, 0 fail.