### PR TITLE
feat: improve desktop usage collection, billing, and hard refresh

### DIFF
--- a/InfoModel.qml
+++ b/InfoModel.qml
@@ -50,6 +50,11 @@ Item {
   // Origin only, e.g. http://127.0.0.1:11435. Empty inherits OLLAMA_HOST.
   property string ollamaHost: ""
 
+  // HARD REFRESH: next collector pass bypasses GitHub / billing / usage TTLs.
+  property bool forceRefreshArmed: false
+  property bool hardRefreshing: false
+  property int dataGeneration: 0
+
   // --- theme ---------------------------------------------------------------
   // Omarchy's Color singleton gives fg/bg/accent/urgent/muted. The ANSI roles
   // (green/yellow/red/blue…) live in the theme's colors.toml; read them here
@@ -178,7 +183,8 @@ Item {
     property bool frameComplete: false
     readonly property int maxOutputBytes: 2 * 1024 * 1024
     readonly property int maxStderrBytes: 4096
-    command: root.demoMode ? ["bun", root.collectorPath, "--id", root.instance, "--demo"] : ["bun", root.collectorPath, "--id", root.instance]
+    property bool forceRun: false
+    command: ["bun", root.collectorPath, "--id", root.instance]
     environment: root.ollamaHost !== "" ? ({ OLLAMA_HOST: root.ollamaHost }) : ({})
 
     function fail(message) {
@@ -216,6 +222,7 @@ Item {
         root.ready = true
         root.snap = parsed
         root.error = ""
+        root.dataGeneration += 1
         frameComplete = true
         outputBuffer = ""
         outputBytes = 0
@@ -230,6 +237,8 @@ Item {
       stderrBytes += added
     }
     onRunningChanged: if (running) {
+      forceRun = root.forceRefreshArmed
+      root.forceRefreshArmed = false
       outputBuffer = ""
       outputBytes = 0
       stderrBytes = 0
@@ -246,16 +255,44 @@ Item {
       onRead: function(line) { collector.acceptStderr(line) }
     }
     onExited: function(exitCode) {
-      if (collector.protocolFailed) return
+      if (collector.forceRun && !root.forceRefreshArmed) root.hardRefreshing = false
+      if (collector.protocolFailed) {
+        if (root.forceRefreshArmed) root.startCollector()
+        return
+      }
       if (!collector.frameComplete) root.error = collector.lastStderr || (exitCode === 0 ? "collector ended without a complete snapshot" : "collector exited " + exitCode)
+      if (root.forceRefreshArmed) root.startCollector()
     }
+  }
+  function collectorCommand() {
+    var cmd = ["bun", root.collectorPath, "--id", root.instance]
+    if (root.demoMode) cmd.push("--demo")
+    else if (root.forceRefreshArmed) cmd.push("--force-refresh")
+    return cmd
+  }
+  function startCollector() {
+    if (collector.running || bunProbe.running) return
+    collector.command = collectorCommand()
+    collector.running = true
   }
   function refresh() {
     if (!root.active || collector.running || bunProbe.running) return
     // Once bun is known-good, skip the probe; re-probe every tick only while
     // it is missing so an install is picked up without a shell restart.
-    if (root.bunChecked && root.bunAvailable) collector.running = true
+    if (root.bunChecked && root.bunAvailable) root.startCollector()
     else bunProbe.running = true
+  }
+  function hardRefresh() {
+    root.forceRefreshArmed = true
+    root.hardRefreshing = true
+    if (collector.running || bunProbe.running) return
+    if (!root.bunChecked) { bunProbe.running = true; return }
+    if (root.bunAvailable) root.startCollector()
+    else {
+      root.hardRefreshing = false
+      root.forceRefreshArmed = false
+      root.error = root.missingDependencyHint
+    }
   }
   Process {
     id: bunProbe
@@ -263,8 +300,12 @@ Item {
     onExited: function(exitCode) {
       root.bunChecked = true
       root.bunAvailable = exitCode === 0
-      if (root.bunAvailable) { if (!collector.running) collector.running = true }
-      else root.error = root.missingDependencyHint
+      if (root.bunAvailable) { if (!collector.running) root.startCollector() }
+      else {
+        root.error = root.missingDependencyHint
+        root.hardRefreshing = false
+        root.forceRefreshArmed = false
+      }
     }
   }
 

--- a/InfoView.qml
+++ b/InfoView.qml
@@ -43,6 +43,7 @@ Item {
     return v.lifetime === null || v.lifetime === undefined || tokens <= 0 ? null : Number(v.lifetime) / tokens
   }
   readonly property var usageSeries: {
+    var _g = view.desk.dataGeneration
     var out = []
     var keys = Object.keys(usage).filter(function(k) { return usage[k] && usage[k].ready !== false && (!usageProviderFilter || usageProviderFilter === k) })
     for (var i = 0; i < keys.length; i++) {
@@ -844,6 +845,16 @@ Item {
         Layout.fillWidth: true
         Layout.preferredHeight: implicitHeight
         spacing: Style.spacing.sm
+        Tag {
+          text: view.desk.hardRefreshing ? "HARD REFRESH …" : "HARD REFRESH"
+          tone: view.desk.hardRefreshing ? view.desk.yellow : view.desk.cyan
+          MouseArea {
+            anchors.fill: parent
+            enabled: view.interactive && !view.desk.hardRefreshing
+            cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+            onClicked: view.desk.hardRefresh()
+          }
+        }
         Repeater {
           model: view.settings.definitions
           delegate: SectionChip { required property var modelData; section: modelData }
@@ -1497,7 +1508,7 @@ Item {
           draggable: true
           title: "USAGE & LIMITS"
           hint: {
-            var keys = Object.keys(view.usage); return keys.length ? "via omarchy agents" : "enable the Agents bar widget"
+            var keys = Object.keys(view.usage); return keys.length ? "omarchy agents · grok/opencode local" : "enable the Agents bar widget"
           }
           ColumnLayout {
             width: parent.width
@@ -1506,7 +1517,10 @@ Item {
               Layout.fillWidth: true
               spacing: Style.spacing.xs
               Repeater {
-                model: Object.keys(view.usage).filter(function(k) { return view.usage[k] && view.usage[k].ready !== false })
+                model: {
+                  var _g = view.desk.dataGeneration
+                  return Object.keys(view.usage).filter(function(k) { return view.usage[k] && view.usage[k].ready !== false })
+                }
                 delegate: Tag {
                   required property string modelData
                   text: view.desk.providerLabel(modelData)
@@ -1615,76 +1629,87 @@ Item {
               }
             }
             Repeater {
-              model: Object.keys(view.usage).filter(function(k) { return view.usage[k] && view.usage[k].ready !== false && (!view.usageProviderFilter || view.usageProviderFilter === k) })
-              delegate: ColumnLayout {
+              model: {
+                var _g = view.desk.dataGeneration
+                return Object.keys(view.usage).filter(function(k) { return view.usage[k] && view.usage[k].ready !== false && (!view.usageProviderFilter || view.usageProviderFilter === k) })
+              }
+              delegate: Rectangle {
                 id: up
                 required property string modelData
                 readonly property var u: view.usage[modelData] || ({})
                 readonly property color tone: view.desk.providerColor(modelData)
                 Layout.fillWidth: true
-                spacing: Style.spacing.xs
-                RowLayout {
-                  Layout.fillWidth: true
-                  PlainText { text: up.u.name || up.modelData; color: up.tone; font.family: view.mono; font.bold: true; font.pixelSize: Style.font.body }
-                  PlainText { text: up.u.tierLabel || ""; color: view.textFaint; font.family: view.mono; font.pixelSize: Style.font.caption }
-                  Item { Layout.fillWidth: true }
-                  PlainText { text: "today " + (up.u.todayPrompts || 0) + "p" + (up.u.todaySessions ? " · " + up.u.todaySessions + " sess" : "") + (up.u.hasTokenData ? " · " + view.desk.tokens(up.u.todayTotalTokens) + " tok" + (up.u.value && up.u.value.today !== null && up.u.value.today !== undefined ? " · ≈" + view.usageMoney(up.u.value.today) : "") : ""); color: view.textDim; font.family: view.mono; font.pixelSize: Style.font.caption }
-                }
-                PlainText {
-                  Layout.fillWidth: true
-                  // A provider with no lifetime tokens has nothing to say here.
-                  visible: !!(up.u.value && up.u.value.totals) && (Number((up.u.value.totals || {}).inputTokens || 0) + Number((up.u.value.totals || {}).outputTokens || 0) + Number((up.u.value.totals || {}).cacheReadInputTokens || 0) + Number((up.u.value.totals || {}).cacheCreationInputTokens || 0)) > 0
-                  elide: Text.ElideRight
-                  text: {
-                    var v = up.u.value || {}, t = v.totals || {}
-                    var all = Number(t.inputTokens || 0) + Number(t.outputTokens || 0) + Number(t.cacheReadInputTokens || 0) + Number(t.cacheCreationInputTokens || 0)
-                    var parts = ["lifetime " + view.desk.tokens(all) + " tok"]
-                    if (all > 0) parts.push(Math.round(100 * Number(t.cacheReadInputTokens || 0) / all) + "% cache reads")
-                    if (v.lifetime !== null && v.lifetime !== undefined) parts.push("≈" + view.usageMoney(v.lifetime) + (v.pricedShare < 0.999 ? " (" + Math.round(v.pricedShare * 100) + "% priced)" : "") + " est.")
-                    else if (all > 0) parts.push("unpriced")
-                    if (up.u.totalSessions) parts.push(up.u.totalSessions + " sessions")
-                    return parts.join(" · ")
-                  }
-                  color: view.textFaint; font.family: view.mono; font.pixelSize: Style.font.caption
-                }
-                // Per-model breakdown. Anthropic gives Fable its own rate-limit
-                // window above; OpenAI and xAI publish no per-model window, so
-                // this is each model's share of the work instead. Driven purely
-                // by what the provider reports — a model released tomorrow
-                // appears here on its own, with no change to this file.
-                Repeater {
-                  model: (up.u.models || []).filter(function(m) { return m && ((m.share || 0) > 0 || (m.sessions || 0) > 0) })
-                  delegate: Meter {
-                    required property var modelData
+                implicitHeight: upColumn.implicitHeight + Style.spacing.sm * 2
+                radius: view.radius
+                color: Util.alpha(up.tone, 0.07)
+                border.color: Util.alpha(up.tone, 0.28)
+                border.width: 1
+                ColumnLayout {
+                  id: upColumn
+                  anchors { left: parent.left; right: parent.right; verticalCenter: parent.verticalCenter; margins: Style.spacing.sm }
+                  spacing: Style.spacing.xs
+                  RowLayout {
                     Layout.fillWidth: true
-                    label: modelData.id || ""
-                    value: up.u.hasTokenData
-                      ? view.desk.tokens(modelData.todayTokens) + " tok  ·  " + Math.round((modelData.share || 0) * 100) + "%"
-                      : (modelData.sessions || 0) + " sess"
-                    // A provider with no token counts has no share to draw.
-                    fraction: up.u.hasTokenData ? (modelData.share || 0) : 0
-                    tone: up.tone
+                    PlainText { text: up.u.name || up.modelData; color: up.tone; font.family: view.mono; font.bold: true; font.pixelSize: Style.font.body }
+                    PlainText { text: up.u.tierLabel || ""; color: view.textFaint; font.family: view.mono; font.pixelSize: Style.font.caption }
+                    Item { Layout.fillWidth: true }
+                    PlainText { text: "today " + (up.u.todayPrompts || 0) + "p" + (up.u.todaySessions ? " · " + up.u.todaySessions + " sess" : "") + (up.u.hasTokenData ? " · " + view.desk.tokens(up.u.todayTotalTokens) + " tok" + (up.u.value && up.u.value.today !== null && up.u.value.today !== undefined ? " · ≈" + view.usageMoney(up.u.value.today) : "") : ""); color: view.textDim; font.family: view.mono; font.pixelSize: Style.font.caption }
                   }
-                }
-                // Why a provider has no limit bars. Absent everywhere else, so it
-                // costs a row only for the provider that needs to explain itself.
-                PlainText {
-                  Layout.fillWidth: true
-                  visible: !!up.u.usageStatusText && !(up.u.limits || []).length
-                  text: up.u.usageStatusText || ""
-                  color: view.textFaint; font.family: view.mono; font.pixelSize: Style.font.caption
-                  elide: Text.ElideRight
-                }
-                Repeater {
-                  model: up.u.limits || []
-                  delegate: Meter {
-                    required property var modelData
-                    readonly property var projection: view.usageProjection(modelData)
+                  PlainText {
                     Layout.fillWidth: true
-                    label: modelData.label || modelData.title || ""
-                    value: (view.usageForecastMode ? (projection === null ? "learning" : "→ " + Math.round(projection * 100) + "% at reset") : Math.round((modelData.percent || 0) * 100) + "%") + (modelData.resetsAt ? "  ↻ " + view.desk.until(Date.parse(modelData.resetsAt)) : "")
-                    fraction: modelData.percent || 0
-                    tone: (modelData.percent || 0) > 0.85 ? view.desk.red : (modelData.percent || 0) > 0.6 ? view.desk.yellow : up.tone
+                    visible: !!up.u.authHelpText
+                    text: up.u.authHelpText || ""
+                    color: view.textFaint; font.family: view.mono; font.pixelSize: Style.font.caption
+                    elide: Text.ElideRight
+                  }
+                  PlainText {
+                    Layout.fillWidth: true
+                    // A provider with no lifetime tokens has nothing to say here.
+                    visible: !!(up.u.value && up.u.value.totals) && (Number((up.u.value.totals || {}).inputTokens || 0) + Number((up.u.value.totals || {}).outputTokens || 0) + Number((up.u.value.totals || {}).cacheReadInputTokens || 0) + Number((up.u.value.totals || {}).cacheCreationInputTokens || 0)) > 0
+                    elide: Text.ElideRight
+                    text: {
+                      var v = up.u.value || {}, t = v.totals || {}
+                      var all = Number(t.inputTokens || 0) + Number(t.outputTokens || 0) + Number(t.cacheReadInputTokens || 0) + Number(t.cacheCreationInputTokens || 0)
+                      var parts = ["lifetime " + view.desk.tokens(all) + " tok"]
+                      if (all > 0) parts.push(Math.round(100 * Number(t.cacheReadInputTokens || 0) / all) + "% cache reads")
+                      if (v.lifetime !== null && v.lifetime !== undefined) parts.push("≈" + view.usageMoney(v.lifetime) + (v.pricedShare < 0.999 ? " (" + Math.round(v.pricedShare * 100) + "% priced)" : "") + " est.")
+                      else if (all > 0) parts.push("unpriced")
+                      if (up.u.totalSessions) parts.push(up.u.totalSessions + " sessions")
+                      return parts.join(" · ")
+                    }
+                    color: view.textFaint; font.family: view.mono; font.pixelSize: Style.font.caption
+                  }
+                  Repeater {
+                    model: (up.u.models || []).filter(function(m) { return m && ((m.share || 0) > 0 || (m.sessions || 0) > 0) })
+                    delegate: Meter {
+                      required property var modelData
+                      Layout.fillWidth: true
+                      label: modelData.id || ""
+                      value: up.u.hasTokenData
+                        ? view.desk.tokens(modelData.todayTokens) + " tok  ·  " + Math.round((modelData.share || 0) * 100) + "%"
+                        : (modelData.sessions || 0) + " sess"
+                      fraction: up.u.hasTokenData ? (modelData.share || 0) : 0
+                      tone: up.tone
+                    }
+                  }
+                  PlainText {
+                    Layout.fillWidth: true
+                    visible: !!up.u.usageStatusText && !(up.u.limits || []).length
+                    text: up.u.usageStatusText || ""
+                    color: view.textFaint; font.family: view.mono; font.pixelSize: Style.font.caption
+                    elide: Text.ElideRight
+                  }
+                  Repeater {
+                    model: up.u.limits || []
+                    delegate: Meter {
+                      required property var modelData
+                      readonly property var projection: view.usageProjection(modelData)
+                      Layout.fillWidth: true
+                      label: modelData.label || modelData.title || ""
+                      value: (view.usageForecastMode ? (projection === null ? "learning" : "→ " + Math.round(projection * 100) + "% at reset") : Math.round((modelData.percent || 0) * 100) + "%") + (modelData.resetsAt ? "  ↻ " + view.desk.until(Date.parse(modelData.resetsAt)) : "")
+                      fraction: modelData.percent || 0
+                      tone: (modelData.percent || 0) > 0.85 ? view.desk.red : (modelData.percent || 0) > 0.6 ? view.desk.yellow : up.tone
+                    }
                   }
                 }
               }

--- a/Infomarchy.qml
+++ b/Infomarchy.qml
@@ -156,6 +156,7 @@ Scope {
   IpcHandler {
     target: "infomarchy"
     function refresh(): void { infoModel.refresh() }
+    function hardRefresh(): void { infoModel.hardRefresh() }
     function setWallpaperOpacity(v: string): void { var n = Number(v); if (isFinite(n)) root.wallpaperOpacity = Math.max(0, Math.min(1, n)) }
     function setDashboardVisible(v: string): void { dashboardSettings.setDashboardVisible(["1", "true", "on", "yes"].indexOf(String(v).toLowerCase()) >= 0) }
     function toggleDashboard(): void { dashboardSettings.toggleDashboardVisible() }

--- a/Overlay.qml
+++ b/Overlay.qml
@@ -57,6 +57,7 @@ Scope {
   // `omarchy-shell shell call nixfred.infomarchy refresh` hits the overlay
   // loader, not the wallpaper IpcHandler.
   function refresh() { infoModel.refresh() }
+  function hardRefresh() { infoModel.hardRefresh() }
 
   Variants {
     model: Quickshell.screens

--- a/README.md
+++ b/README.md
@@ -264,6 +264,16 @@ Still and animated image wallpapers share one image surface. Supported animated 
 A hideable, reorderable MEDIA CONTROLS card uses the local MPRIS service for title, artist, album, player identity, and previous/play-pause/next actions. A playing player is preferred, and playerctld is used only when no other player exists. Metadata is bounded plain text; album art is never fetched. Demo mode shows sample metadata and disables actions.
 Pi sessions are detected from the `pi` process and `~/.pi/agent/sessions` JSONL history. Recent Tasks includes Pi prompts, activity, and resume via `pi --session <id>`. The recent-task window reserves space for quieter providers while retaining pinned-first and newest-first display order.
 
+### Usage collection and refresh
+
+When Omarchy has no usage record, Grok `updates.jsonl` cumulative snapshots and OpenCode assistant token fields supply local totals. OpenCode cache invalidation includes its SQLite WAL and the local date. Grok falls back to session-directory counts when no token snapshots exist; observed billing limits remain independent of token availability. Providers appear in separate tinted blocks.
+
+Grok billing uses the local CLI credential in an Authorization header to its fixed HTTPS billing endpoint, with redirects refused and bounded response size/time. Wallpaper and overlay share a 60-second cache and a descriptor-held `flock`; failures back off too. `INFOMARCHY_SKIP_GROK_BILLING=1` disables the fetch. No credentials enter argv or the snapshot.
+
+When Claude's saved OAuth access token expires, the wallpaper collector may run `claude -p ping --max-turns 0`, at most every 15 minutes, to let the CLI refresh it, then read `--limits-only` in memory. `INFOMARCHY_SKIP_CLAUDE_USAGE=1` disables this. Successful limits no longer retain stale sign-in help. Omarchy's usage cache files are never written by Infomarchy.
+
+The first module-strip chip, **HARD REFRESH**, bypasses cached Grok billing, GitHub activity, external-IP and local usage reads, and re-reads Claude limits. IPC: `omarchy-shell infomarchy hardRefresh` or `omarchy-shell shell call nixfred.infomarchy hardRefresh` for the overlay. Explicit refresh still honors the skip environment variables.
+
 ## FAQ
 
 **Does it drain my battery?** One `bun` run every 4 s (~0.2 s of CPU warm), no idle animation except the busy-dot pulse — a few percent of one core at most. Raise `refreshMs` if you want it lower.

--- a/collector.test.ts
+++ b/collector.test.ts
@@ -1,9 +1,10 @@
+import { parseGrokCreditsConfig, grokBillingFromUnifiedLog, grokObservedLimits, grokBillingRefreshDue, GROK_BILLING_REFRESH_MS, forceRefreshRequested, sqliteUsageIdentity, withGrokObservedLimits, refreshGrokBilling, claudeOauthExpiredAt } from "./collector.ts";
 import { afterAll, describe, expect, test } from "bun:test";
 import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { Database } from "bun:sqlite";
 import { tmpdir } from "os";
 import { join, relative } from "path";
-import { providerOf, titleLooksBusy, cmdIsTurnInhibitor, sessionIdFrom, sessionHostsFromEnvironment, tmuxSocketFromEnvironment, parseTmuxPanes, parseTmuxClients, tmuxPaneForAncestors, linkRecentToLive, inferSessionIdsFromRecent, attachSessionTopics, localSessionSummary, cleanGeneratedSummary, activityCellIndex, parseExternalIpTrace, externalIpCacheFresh, frameSnapshot, parseJsonBounded, readRegularFileLimited, safePrompt, sessionPresentation, writePrivateStateFile, decodeProjectDir, dropPartialFirstLine, readHistoryTail, readRegularFileHead, rolloutSessionId, rolloutCwd, topicCacheHit, topicRetryBlocked, pruneTopicCache, reapStateTempFiles, parseGpuLine, parseDfRows, plausibleTimestamp, normalizeUsage, normalizeUsageLimit, ollamaHostIsLocal, topicRefinementAllowed, terminate, rateForModel, estimateValue, valueSummary, alignDailyTokens, localDayKey, loadPricing, todayValueEstimate, herdrSocketFromEnvironment, herdrClientPids, herdrWindowFor, boomuxClientShellId, boomuxWindowFor, backgroundDaemonKind, parseClaudeAgents, sessionStaleness, STALE_AFTER_MS, decodeBase32, grokBotLine, grokBotRow, grokBotAttention, attachGrokBotRoster, grokSessionUsage, usageModelBreakdown, windowMatchesProvider, hermesSessionByPid, validNetDevice, observationalGitCommand, observationalGitEnv, piUserText, piSessionIdFromName } from "./collector.ts";
+import { providerOf, titleLooksBusy, cmdIsTurnInhibitor, sessionIdFrom, sessionHostsFromEnvironment, tmuxSocketFromEnvironment, parseTmuxPanes, parseTmuxClients, tmuxPaneForAncestors, linkRecentToLive, inferSessionIdsFromRecent, attachSessionTopics, localSessionSummary, cleanGeneratedSummary, activityCellIndex, parseExternalIpTrace, externalIpCacheFresh, frameSnapshot, parseJsonBounded, readRegularFileLimited, safePrompt, sessionPresentation, writePrivateStateFile, decodeProjectDir, dropPartialFirstLine, readHistoryTail, readRegularFileHead, rolloutSessionId, rolloutCwd, topicCacheHit, topicRetryBlocked, pruneTopicCache, reapStateTempFiles, parseGpuLine, parseDfRows, plausibleTimestamp, normalizeUsage, normalizeUsageLimit, ollamaHostIsLocal, topicRefinementAllowed, terminate, rateForModel, estimateValue, valueSummary, alignDailyTokens, localDayKey, loadPricing, todayValueEstimate, herdrSocketFromEnvironment, herdrClientPids, herdrWindowFor, boomuxClientShellId, boomuxWindowFor, backgroundDaemonKind, parseClaudeAgents, sessionStaleness, STALE_AFTER_MS, decodeBase32, grokBotLine, grokBotRow, grokBotAttention, attachGrokBotRoster, grokSessionUsage, usageModelBreakdown, windowMatchesProvider, hermesSessionByPid, validNetDevice, observationalGitCommand, observationalGitEnv, piUserText, piSessionIdFromName, grokUsageFromUpdate, grokUsageFromUpdatesText, foldGrokSessionSnaps } from "./collector.ts";
 import { sessionEventId } from "./notification-events.ts";
 
 const testRoot = mkdtempSync(join(tmpdir(), "infomarchy-test-"));
@@ -609,6 +610,63 @@ describe("history collection", () => {
     });
     rmSync(root, { recursive: true, force: true });
   });
+
+  test("OpenCode assistant tokens become a local usage row", async () => {
+    const root = join(testRoot, "opencode-usage");
+    const data = join(root, "data");
+    mkdirSync(join(data, "opencode"), { recursive: true });
+    const db = new Database(join(data, "opencode", "opencode.db"));
+    db.exec(`CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);`);
+    const ts = Date.now();
+    db.query("INSERT INTO message VALUES (?, ?, ?, ?)").run("a1", "ses_aaaaaaa1", ts, JSON.stringify({
+      role: "assistant", modelID: "qwen3.8-flash", tokens: { input: 10, output: 20, reasoning: 5, cache: { read: 100, write: 50 } },
+    }));
+    db.query("INSERT INTO message VALUES (?, ?, ?, ?)").run("u1", "ses_aaaaaaa1", ts, JSON.stringify({ role: "user" }));
+    db.close();
+    const proc = Bun.spawn(["bun", join(import.meta.dir, "collector.ts")], {
+      env: { HOME: root, USER: "tester", XDG_DATA_HOME: data, XDG_STATE_HOME: join(root, "state"), PATH: process.env.PATH || "", INFOMARCHY_SKIP_EXTERNAL_IP: "1" },
+      stdout: "pipe", stderr: "pipe",
+    });
+    const snap = decodeFrames(await new Response(proc.stdout).text());
+    expect(await proc.exited).toBe(0);
+    expect(snap.ai.usage.opencode.tierLabel).toBe("local");
+    expect(snap.ai.usage.opencode.limits).toEqual([]);
+    expect(snap.ai.usage.opencode.usageStatusText).toContain("not subscription");
+    expect(snap.ai.usage.opencode.modelUsage["qwen3.8-flash"]).toMatchObject({
+      inputTokens: 10, outputTokens: 25, cacheReadInputTokens: 100, cacheCreationInputTokens: 50,
+    });
+    expect(snap.ai.usage.opencode.todayTotalTokens).toBe(185);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("Grok updates.jsonl cumulative usage becomes a local usage row", async () => {
+    const root = join(testRoot, "grok-usage");
+    const session = join(root, ".grok", "sessions", "proj", "session-aaaa");
+    mkdirSync(session, { recursive: true });
+    // Pin both cumulative samples and the collector to the same UTC day.
+    const t2 = Date.now();
+    const t1 = new Date(t2).setUTCHours(0, 0, 0, 0);
+    const line = (ts: number, input: number, output: number) => JSON.stringify({
+      timestamp: ts,
+      params: { update: { usage: {
+        inputTokens: input, outputTokens: output, reasoningTokens: 0, cachedReadTokens: 0, cacheCreationTokens: 0, totalTokens: input + output,
+        modelUsage: { "grok-4.6-build": { inputTokens: input, outputTokens: output, reasoningTokens: 0, cachedReadTokens: 0, cacheCreationTokens: 0 } },
+      } } },
+    });
+    writeFileSync(join(session, "updates.jsonl"), [line(t1, 100, 10), line(t2, 250, 40)].join("\n") + "\n");
+    writeFileSync(join(session, "..", "prompt_history.jsonl"), JSON.stringify({ timestamp: new Date(t2).toISOString(), session_id: "session-aaaa", prompt: "hello" }) + "\n");
+    const proc = Bun.spawn(["bun", join(import.meta.dir, "collector.ts")], {
+      env: { TZ: "UTC", HOME: root, USER: "tester", GROK_HOME: join(root, ".grok"), XDG_STATE_HOME: join(root, "state"), PATH: process.env.PATH || "", INFOMARCHY_SKIP_EXTERNAL_IP: "1" },
+      stdout: "pipe", stderr: "pipe",
+    });
+    const snap = decodeFrames(await new Response(proc.stdout).text());
+    expect(await proc.exited).toBe(0);
+    expect(snap.ai.usage.grok.tierLabel).toBe("local");
+    expect(snap.ai.usage.grok.limits).toEqual([]);
+    expect(snap.ai.usage.grok.modelUsage["grok-4.6-build"].inputTokens).toBe(250);
+    expect(snap.ai.usage.grok.todayTotalTokens).toBe(290);
+    rmSync(root, { recursive: true, force: true });
+  });
 });
 
 describe("degrading instead of crashing", () => {
@@ -803,6 +861,19 @@ describe("second-reviewer findings (2026-09-04)", () => {
     expect(plausibleTimestamp(Date.UTC(2099, 0, 1), stamp)).toBe(false);
     expect(plausibleTimestamp(0, stamp)).toBe(false);
     expect(plausibleTimestamp("nope", stamp)).toBe(false);
+  });
+
+  test("Grok usage snapshots fold cumulative totals into per-day deltas", () => {
+    const snaps = grokUsageFromUpdatesText([
+      JSON.stringify({ timestamp: Date.UTC(2026, 8, 5, 12), params: { usage: { inputTokens: 100, outputTokens: 20, cachedReadTokens: 0, cacheCreationTokens: 0, modelUsage: { m: { inputTokens: 100, outputTokens: 20 } } } } }),
+      JSON.stringify({ timestamp: Date.UTC(2026, 8, 6, 12), params: { usage: { inputTokens: 180, outputTokens: 40, cachedReadTokens: 0, cacheCreationTokens: 0, modelUsage: { m: { inputTokens: 180, outputTokens: 40 } } } } }),
+    ].join("\n"));
+    expect(snaps).toHaveLength(2);
+    const folded = foldGrokSessionSnaps(snaps);
+    expect(folded.last?.usage.inputTokens).toBe(180);
+    expect(folded.daily.get("2026-09-05")).toBe(120);
+    expect(folded.daily.get("2026-09-06")).toBe(100);
+    expect(grokUsageFromUpdate({ inputTokens: 0, outputTokens: 0 })).toBeNull();
   });
 
   test("usage caches are normalized to displayed fields with hard bounds", () => {
@@ -1321,4 +1392,181 @@ describe("zombie detection", () => {
     expect(sessionStaleness({ startedAt: 1000, topicAt: 5000, hosts: [], window: null }, now).idleSince).toBe(5000);
     expect(sessionStaleness({ startedAt: 7000, topicAt: 0, hosts: [], window: null }, now).idleSince).toBe(7000);
   });
+});
+
+  test("Grok credits config uses 0-100 percents and product rows", () => {
+    const parsed = parseGrokCreditsConfig({
+      config: {
+        creditUsagePercent: 17,
+        currentPeriod: { type: "USAGE_PERIOD_TYPE_WEEKLY", end: "2026-09-14T07:26:13Z" },
+        productUsage: [{ product: "GrokBuild", usagePercent: 14 }, { product: "GrokVoice", usagePercent: 3 }],
+      },
+    });
+    expect(parsed).toEqual({
+      percent: 0.17,
+      resetsAt: "2026-09-14T07:26:13Z",
+      products: [{ label: "BUILD", percent: 0.14 }, { label: "VOICE", percent: 0.03 }],
+    });
+    const log = grokBillingFromUnifiedLog(JSON.stringify({
+      msg: "billing: fetched credits config",
+      ctx: { config: { creditUsagePercent: 16, currentPeriod: { end: "2026-09-14T07:26:13Z" }, productUsage: [] } },
+    }) + "\n");
+    expect(log?.percent).toBe(0.16);
+    const dir = join(testRoot, "grok-billing");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "grok-billing.json"), JSON.stringify({
+      limits: [{ label: "WEEKLY", percent: 0.17, resetsAt: "2026-09-14T07:26:13Z" }, { label: "BUILD", percent: 0.14, resetsAt: "2026-09-14T07:26:13Z" }],
+    }));
+    expect(grokObservedLimits(dir).map((row: any) => row.label)).toEqual(["WEEKLY", "BUILD"]);
+    expect(grokObservedLimits(dir)[0].percent).toBe(0.17);
+  });
+
+  test("Grok billing refresh is due after 60s, immediately on force, and never when skipped", () => {
+    const stamp = 1_000_000;
+    const fresh = { attemptedAt: stamp - GROK_BILLING_REFRESH_MS + 1, limits: [{ label: "WEEKLY", percent: 0.02 }] };
+    expect(grokBillingRefreshDue(fresh, stamp)).toBe(false);
+    expect(grokBillingRefreshDue(fresh, stamp, true)).toBe(true);
+    expect(grokBillingRefreshDue({ attemptedAt: stamp - GROK_BILLING_REFRESH_MS, limits: [{ label: "WEEKLY", percent: 0.02 }] }, stamp)).toBe(true);
+    expect(grokBillingRefreshDue({ attemptedAt: stamp, limits: [] }, stamp)).toBe(false);
+    expect(grokBillingRefreshDue({}, stamp)).toBe(true);
+    expect(forceRefreshRequested(["bun", "collector.ts"])).toBe(false);
+    expect(forceRefreshRequested(["bun", "collector.ts", "--force-refresh"])).toBe(true);
+    const previous = process.env.INFOMARCHY_SKIP_GROK_BILLING;
+    process.env.INFOMARCHY_SKIP_GROK_BILLING = "1";
+    try {
+      expect(grokBillingRefreshDue(fresh, stamp)).toBe(false);
+      expect(grokBillingRefreshDue(fresh, stamp, true)).toBe(false);
+    }
+    finally {
+      if (previous === undefined) delete process.env.INFOMARCHY_SKIP_GROK_BILLING;
+      else process.env.INFOMARCHY_SKIP_GROK_BILLING = previous;
+    }
+  });
+
+describe("OpenCode usage cache invalidation", () => {
+  test("WAL commits and local midnight invalidate otherwise unchanged usage", () => {
+    const path = join(testRoot, "usage-wal.db");
+    const db = new Database(path);
+    try {
+      db.exec("PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE message (tokens INTEGER); INSERT INTO message VALUES (100); PRAGMA wal_checkpoint(TRUNCATE)");
+      const today = new Date(2026, 8, 9, 12).getTime();
+      const before = sqliteUsageIdentity(path, today);
+      expect(before).not.toBeNull();
+      expect(sqliteUsageIdentity(path, today)).toBe(before);
+      const main = lstatSync(path, { bigint: true });
+      db.exec("INSERT INTO message VALUES (200)");
+      expect(lstatSync(path, { bigint: true }).mtimeNs).toBe(main.mtimeNs);
+      expect(lstatSync(path, { bigint: true }).size).toBe(main.size);
+      const committed = sqliteUsageIdentity(path, today);
+      expect(committed).not.toBe(before);
+      expect(sqliteUsageIdentity(path, new Date(2026, 8, 10, 0).getTime())).not.toBe(committed);
+      db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+      expect(sqliteUsageIdentity(path, today)).not.toBe(committed);
+    } finally { db.close(); }
+    expect(sqliteUsageIdentity(join(testRoot, "missing.db"))).toBeNull();
+  });
+});
+
+describe("Grok billing without token snapshots", () => {
+  test("attaches observed limits to session-only usage without inventing tokens", () => {
+    const dir = join(testRoot, "grok-session-billing");
+    mkdirSync(dir, { recursive: true });
+    const sessions = normalizeUsage({ name: "Grok", totalSessions: 3, todaySessions: 1, modelSessions: { grok: 3 }, limits: [] });
+    expect(withGrokObservedLimits(sessions, dir).limits).toEqual([]);
+    writeFileSync(join(dir, "grok-billing.json"), JSON.stringify({ limits: [{ label: "WEEKLY", percent: 0.17 }] }));
+    const result = withGrokObservedLimits(sessions, dir);
+    expect(result.limits[0].percent).toBe(0.17);
+    expect(result.tierLabel).toBe("weekly");
+    expect(result.hasTokenData).toBe(false);
+    expect(result.todaySessions).toBe(1);
+    expect(result.totalSessions).toBe(3);
+    expect(result.models).toEqual(sessions.models);
+    expect(result.usageStatusText).toContain("session counts");
+    expect(sessions.limits).toEqual([]);
+    // A new billing result must be visible even when the local record is cached.
+    writeFileSync(join(dir, "grok-billing.json"), JSON.stringify({ limits: [{ label: "WEEKLY", percent: 0.28 }] }));
+    expect(withGrokObservedLimits(sessions, dir).limits[0].percent).toBe(0.28);
+    const tokens = normalizeUsage({ name: "Grok", todayTotalTokens: 100, limits: [] });
+    expect(withGrokObservedLimits(tokens, dir).usageStatusText).toContain("token totals");
+  });
+});
+
+describe("Grok billing backoff and mutual exclusion", () => {
+  test("failed first fetch backs off, expires after 60 seconds, and allows hard refresh", async () => {
+    const directory = join(testRoot, "billing-failure");
+    let calls = 0;
+    const options = { directory, readLog: () => "", fetchBilling: async () => { calls++; return null; } };
+    await refreshGrokBilling({ ...options, stamp: 1_000_000 });
+    await refreshGrokBilling({ ...options, stamp: 1_000_001 });
+    expect(calls).toBe(1);
+    await refreshGrokBilling({ ...options, stamp: 1_060_000 });
+    expect(calls).toBe(2);
+    await refreshGrokBilling({ ...options, stamp: 1_060_001, force: true });
+    expect(calls).toBe(3);
+  });
+
+  test("overlapping collectors share a lock, including hard refresh, and release after errors", async () => {
+    const directory = join(testRoot, "billing-overlap");
+    let entered!: () => void, release!: () => void;
+    const started = new Promise<void>(resolve => { entered = resolve; });
+    const blocked = new Promise<void>(resolve => { release = resolve; });
+    let calls = 0;
+    const options = { directory, stamp: 2_000_000, readLog: () => "" };
+    const first = refreshGrokBilling({ ...options, fetchBilling: async () => {
+      calls++;
+      entered();
+      await blocked;
+      throw new Error("simulated interrupted fetch");
+    } });
+    try {
+      await started;
+      expect(JSON.parse(readFileSync(join(directory, "grok-billing.json"), "utf8")).attemptedAt).toBe(options.stamp);
+      await refreshGrokBilling({ ...options, force: true, fetchBilling: async () => { calls++; return null; } });
+      expect(calls).toBe(1);
+    } finally { release(); await first; }
+    await refreshGrokBilling({ ...options, force: true, fetchBilling: async () => { calls++; return { creditUsagePercent: 25 }; } });
+    expect(calls).toBe(2);
+    expect(grokObservedLimits(directory)[0].percent).toBe(0.25);
+    // A later outage preserves the successful result while recording backoff.
+    await refreshGrokBilling({ ...options, stamp: 2_060_000, fetchBilling: async () => null });
+    expect(grokObservedLimits(directory)[0].percent).toBe(0.25);
+  });
+
+  test("a killed collector releases its lock for the next hard refresh", async () => {
+    const directory = join(testRoot, "billing-killed");
+    const script = `import { refreshGrokBilling } from ${JSON.stringify(join(import.meta.dir, "collector.ts"))};
+      await refreshGrokBilling({ directory: process.argv[1], force: true, readLog: () => "",
+        fetchBilling: async () => { console.log("locked"); await Bun.sleep(60000); return null; } });`;
+    const child = Bun.spawn([process.execPath, "-e", script, directory], { stdout: "pipe", stderr: "ignore" });
+    try {
+      const reader = child.stdout.getReader();
+      const chunk = await reader.read();
+      expect(new TextDecoder().decode(chunk.value).trim()).toBe("locked");
+      reader.releaseLock();
+      child.kill("SIGKILL");
+      await child.exited;
+      let called = false;
+      await refreshGrokBilling({ directory, force: true, readLog: () => "", fetchBilling: async () => { called = true; return null; } });
+      expect(called).toBe(true);
+    } finally { await terminate(child); }
+  });
+
+  test("a planted lock symlink is refused without touching its target", async () => {
+    const directory = join(testRoot, "billing-lock-symlink");
+    mkdirSync(directory, { recursive: true });
+    const target = join(testRoot, "lock-victim");
+    writeFileSync(target, "must survive");
+    symlinkSync(target, join(directory, "grok-billing.lock"));
+    let called = false;
+    await refreshGrokBilling({ directory, force: true, fetchBilling: async () => { called = true; return null; }, readLog: () => "" });
+    expect(called).toBe(false);
+    expect(readFileSync(target, "utf8")).toBe("must survive");
+  });
+});
+
+test("Claude auth help follows status and OAuth expiry is explicit", () => {
+  expect(normalizeUsage({authHelpText: "Run claude auth login", limits: [{label:"Weekly", percent:0.2}]}).authHelpText).toBe("");
+  expect(normalizeUsage({usageStatusText: "expired", authHelpText: "Sign in"}).authHelpText).toBe("Sign in");
+  expect(claudeOauthExpiredAt(1000, 1001)).toBe(true);
+  expect(claudeOauthExpiredAt(2000, 1001)).toBe(false);
 });

--- a/collector.ts
+++ b/collector.ts
@@ -28,6 +28,10 @@ function instanceId(): string {
   const raw = i >= 0 ? String(process.argv[i + 1] || "") : "bg";
   return raw.replace(/[^A-Za-z0-9_-]/g, "").slice(0, 32) || "bg";
 }
+export function forceRefreshRequested(argv = process.argv): boolean {
+  return argv.includes("--force-refresh") || process.env.INFOMARCHY_FORCE_REFRESH === "1";
+}
+const FORCE_REFRESH = forceRefreshRequested();
 const PREV_FILE = join(STATE_DIR, `prev-${instanceId()}.json`);
 // Shared by every collector instance: the GitHub rows are the same for the
 // wallpaper and the overlay, and one 7-day store means one set of API calls.
@@ -352,7 +356,7 @@ export function externalIpCacheFresh(cached: any, stamp = Date.now()): boolean {
 async function externalIp() {
   const cached = prev.externalIp || {};
   // Cache failures too, otherwise a disconnected host would retry every tick.
-  if (externalIpCacheFresh(cached, now)) return cached;
+  if (!FORCE_REFRESH && externalIpCacheFresh(cached, now)) return cached;
   if (process.env.INFOMARCHY_SKIP_EXTERNAL_IP === "1") return { address: cached.address || null, checkedAt: now };
   try {
     const response = await fetch("https://1.1.1.1/cdn-cgi/trace", { signal: AbortSignal.timeout(1200) });
@@ -375,7 +379,8 @@ const GITHUB_WRITER = instanceId() !== "overlay";
 async function githubActivity() {
   const ghAvailable = !!Bun.which("gh");
   const store = parseGithubStoreText(read(GITHUB_FILE));
-  if (GITHUB_WRITER && ghAvailable && githubFetchEnabled() && githubRefreshDue(store, now)) {
+  const githubDue = FORCE_REFRESH || githubRefreshDue(store, now);
+  if ((GITHUB_WRITER || FORCE_REFRESH) && ghAvailable && githubFetchEnabled() && githubDue) {
     await refreshGithubActivity(store, now, run, ghAvailable);
     try { writePrivateStateFile(STATE_DIR, basename(GITHUB_FILE), JSON.stringify(store)); } catch {}
   }
@@ -2213,6 +2218,11 @@ export function normalizeUsage(j: any, stamp = now): any {
   const lifetime = valueSummary(j.modelUsage && typeof j.modelUsage === "object" ? j.modelUsage : {});
   const todayValue = todayValueEstimate(j.todayTokensByModel && typeof j.todayTokensByModel === "object" ? j.todayTokensByModel : {}, j.modelUsage && typeof j.modelUsage === "object" ? j.modelUsage : {});
   const dayKeys = heatDays.map(localDayKey);
+  const usageStatusText = uiString(j.usageStatusText, 160);
+  // Omarchy's collector seeds authHelpText with "Run `claude auth login`…"
+  // even on a successful limits probe. The desk then looks expired until a
+  // CLI poke refreshes the meters. Help is only real when a status is set.
+  const authHelpText = usageStatusText ? uiString(j.authHelpText, 200) : "";
   return {
     name: uiString(j.name, 64), ready: j.ready !== false, tierLabel: uiString(j.tierLabel, 32),
     // A provider that publishes no token counts must not read as one that used
@@ -2223,8 +2233,10 @@ export function normalizeUsage(j: any, stamp = now): any {
     // the QML re-derive it (the copy there had drifted out of test coverage).
     limits: (Array.isArray(j.limits) ? j.limits : []).slice(0, 16).map((limit: any) => normalizeUsageLimit(limit, stamp)).filter(Boolean),
     todayPrompts: count(j.todayPrompts), todaySessions: count(j.todaySessions), todayTotalTokens: count(j.todayTotalTokens),
-    totalPrompts: count(j.totalPrompts), totalSessions: count(j.totalSessions), updatedAt: count(j.updatedAt),
-    modelUsage, recentDays, usageStatusText: uiString(j.usageStatusText, 160),
+    totalPrompts: count(j.totalPrompts), totalSessions: count(j.totalSessions),
+    updatedAt: typeof j.updatedAt === "string" ? uiString(j.updatedAt, 40) : count(j.updatedAt),
+    modelUsage, recentDays, usageStatusText,
+    authHelpText,
     // Seven aligned daily token totals (oldest first) for the trend chart, and
     // API-value estimates from the attributed price table.
     dailyTokens: alignDailyTokens(j.recentDays, dayKeys),
@@ -2236,6 +2248,481 @@ export function normalizeUsage(j: any, stamp = now): any {
     },
   };
 }
+const LOCAL_USAGE_STATUS = "local session totals, not subscription limits";
+const GROK_BILLING_FILE = "grok-billing.json";
+const GROK_BILLING_URL = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
+export const GROK_BILLING_REFRESH_MS = 60 * 1000;
+const GROK_PRODUCT_LABELS: Record<string, string> = {
+  GrokBuild: "BUILD", PRODUCT_GROK_BUILD: "BUILD",
+  GrokVoice: "VOICE", PRODUCT_GROK_VOICE: "VOICE",
+  GrokChat: "CHAT", PRODUCT_GROK_CHAT: "CHAT",
+  GrokImagine: "IMAGINE", PRODUCT_GROK_IMAGINE: "IMAGINE",
+};
+export function parseGrokCreditsConfig(value: any): { percent: number; resetsAt: string; products: { label: string; percent: number }[] } | null {
+  if (!value || typeof value !== "object") return null;
+  const cfg = value.config && typeof value.config === "object" ? value.config : value;
+  const raw = Number(cfg.creditUsagePercent);
+  if (!Number.isFinite(raw) || raw < 0) return null;
+  const percent = Math.max(0, Math.min(1, raw / 100));
+  const period = cfg.currentPeriod && typeof cfg.currentPeriod === "object" ? cfg.currentPeriod : {};
+  const resetsAt = uiString(period.end || cfg.billingPeriodEnd, 40);
+  const products: { label: string; percent: number }[] = [];
+  const rows = Array.isArray(cfg.productUsage) ? cfg.productUsage : [];
+  for (const row of rows.slice(0, 4)) {
+    if (!row || typeof row !== "object") continue;
+    const p = Number(row.usagePercent);
+    if (!Number.isFinite(p) || p < 0) continue;
+    const key = uiString(row.product, 32);
+    const label = GROK_PRODUCT_LABELS[key] || key.replace(/^Grok/i, "").toUpperCase().slice(0, 12);
+    if (label) products.push({ label, percent: Math.max(0, Math.min(1, p / 100)) });
+  }
+  return { percent, resetsAt, products };
+}
+export function grokBillingFromUnifiedLog(text: string): { percent: number; resetsAt: string; products: { label: string; percent: number }[] } | null {
+  let latest: any = null;
+  for (const line of String(text || "").split("\n")) {
+    if (!line.includes("billing: fetched credits config")) continue;
+    const parsed = parseJsonBounded(line, 4096, 8);
+    if (parsed && typeof parsed === "object" && parsed.msg === "billing: fetched credits config") latest = parsed;
+  }
+  const ctx = latest && latest.ctx && typeof latest.ctx === "object" ? latest.ctx : null;
+  return ctx ? parseGrokCreditsConfig(ctx) : null;
+}
+function grokBillingMeters(parsed: { percent: number; resetsAt: string; products: { label: string; percent: number }[] } | null): any[] {
+  if (!parsed) return [];
+  const out: any[] = [{ label: "WEEKLY", title: "WEEKLY", percent: parsed.percent, resetsAt: parsed.resetsAt }];
+  for (const row of parsed.products.slice(0, 3)) {
+    if (row.label === "WEEKLY") continue;
+    out.push({ label: row.label, title: row.label, percent: row.percent, resetsAt: parsed.resetsAt });
+  }
+  return out;
+}
+function grokCliAccessToken(): string {
+  const path = join(process.env.GROK_HOME || join(HOME, ".grok"), "auth.json");
+  let fd = -1;
+  try {
+    fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+    const st = fstatSync(fd);
+    const uid = typeof process.getuid === "function" ? process.getuid() : -1;
+    if (!st.isFile() || st.nlink !== 1 || (uid >= 0 && st.uid !== uid) || (st.mode & 0o077) || st.size > 16_384) return "";
+    const buf = Buffer.allocUnsafe(st.size);
+    const n = readSync(fd, buf, 0, buf.byteLength, 0);
+    const parsed = parseJsonBounded(buf.subarray(0, n).toString("utf8"), 16_384, 8);
+    if (!parsed || typeof parsed !== "object") return "";
+    let expired = "";
+    for (const rec of Object.values(parsed)) {
+      if (!rec || typeof rec !== "object") continue;
+      const key = String((rec as any).key || "");
+      if (key.length < 20 || key.length > 4000) continue;
+      const exp = Date.parse(String((rec as any).expires_at || ""));
+      if (Number.isFinite(exp) && exp < now - 30_000) { if (!expired) expired = key; continue; }
+      return key;
+    }
+    return expired;
+  } catch { return ""; }
+  finally { if (fd >= 0) try { closeSync(fd); } catch {} }
+  return "";
+}
+async function fetchGrokBilling(): Promise<any | null> {
+  const token = grokCliAccessToken();
+  if (!token) return null;
+  try {
+    const r = await fetch(GROK_BILLING_URL, {
+      redirect: "error",
+      signal: AbortSignal.timeout(4000),
+      headers: {
+        Authorization: "Bearer " + token,
+        "X-XAI-Token-Auth": "xai-grok-cli",
+        Accept: "application/json",
+        "user-agent": "xai-grok-cli",
+      },
+    });
+    if (!r.ok) return null;
+    const text = await boundedStream(r.body, 16 * 1024);
+    if (text === null) return null;
+    const parsed = parseJsonBounded(text, 16 * 1024, 8);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch { return null; }
+}
+export function grokBillingRefreshDue(existing: any, stamp: number, force = false): boolean {
+  if (process.env.INFOMARCHY_SKIP_GROK_BILLING === "1") return false;
+  if (force) return true;
+  const attemptedAt = Number(existing && existing.attemptedAt || existing && existing.fetchedAt || 0);
+  if (attemptedAt && stamp - attemptedAt < GROK_BILLING_REFRESH_MS) return false;
+  return true;
+}
+// flock operates on the inherited stdin descriptor's open-file description.
+// Keeping our descriptor open holds the lock after flock exits; closing it
+// (including process death) releases it. Never unlink/replace the lock inode.
+async function withGrokBillingLock(directory: string, action: () => Promise<void>): Promise<void> {
+  if (!ensurePrivateStateDir(directory)) return;
+  let fd = -1;
+  try {
+    fd = openSync(join(directory, "grok-billing.lock"), constants.O_RDWR | constants.O_CREAT | constants.O_NOFOLLOW | constants.O_NONBLOCK, 0o600);
+    const state = fstatSync(fd);
+    if (!state.isFile() || state.nlink !== 1 || state.uid !== process.getuid!() || (state.mode & 0o077) || state.size !== 0) return;
+    const proc = Bun.spawn(["/usr/bin/flock", "--nonblock", "0"], { stdin: fd, stdout: "ignore", stderr: "ignore" });
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const code = await Promise.race([proc.exited, new Promise<number>(resolve => { timer = setTimeout(() => resolve(-1), 1000); })]);
+    clearTimeout(timer);
+    if (code === -1) { await terminate(proc); return; }
+    if (code !== 0) return;
+    await action();
+  } catch {}
+  finally { if (fd >= 0) try { closeSync(fd); } catch {} }
+}
+export async function refreshGrokBilling(options: {
+  directory?: string; stamp?: number; force?: boolean;
+  fetchBilling?: () => Promise<any>; readLog?: () => string;
+} = {}) {
+  if (process.env.INFOMARCHY_SKIP_GROK_BILLING === "1") return;
+  const directory = options.directory ?? STATE_DIR;
+  const cached = parseJsonBounded(readRegularFileLimited(join(directory, GROK_BILLING_FILE), 4096) || "", 4096, 8);
+  if (!grokBillingRefreshDue(cached, options.stamp ?? Date.now(), options.force ?? FORCE_REFRESH)) return;
+  await withGrokBillingLock(directory, async () => {
+    const stamp = options.stamp ?? Date.now();
+    const existing = parseJsonBounded(readRegularFileLimited(join(directory, GROK_BILLING_FILE), 4096) || "", 4096, 8);
+    if (!grokBillingRefreshDue(existing, stamp, options.force ?? FORCE_REFRESH)) return;
+    // Persist the attempt before I/O, so failures and interrupted collectors
+    // receive the same backoff as successful requests.
+    const attempted = { ...(existing && typeof existing === "object" ? existing : {}), attemptedAt: stamp };
+    if (!writePrivateStateFile(directory, GROK_BILLING_FILE, JSON.stringify(attempted) + "\n")) return;
+    const live = parseGrokCreditsConfig(await (options.fetchBilling ?? fetchGrokBilling)());
+    const fromLog = live ? null : grokBillingFromUnifiedLog(options.readLog ? options.readLog() : (readHistoryTail(join(process.env.GROK_HOME || join(HOME, ".grok"), "logs", "unified.jsonl"), 64 * 1024) || ""));
+    const parsed = live || fromLog;
+    if (!parsed) return;
+    const next = { fetchedAt: stamp, attemptedAt: stamp, source: live ? "live" : "log", percent: parsed.percent, resetsAt: parsed.resetsAt, products: parsed.products, limits: grokBillingMeters(parsed) };
+    writePrivateStateFile(directory, GROK_BILLING_FILE, JSON.stringify(next) + "\n");
+  });
+}
+function normalizeLimitRows(rows: unknown, fallbackReset = ""): any[] {
+  const out: any[] = [];
+  if (!Array.isArray(rows)) return out;
+  for (const row of rows.slice(0, 4)) {
+    if (!row || typeof row !== "object") continue;
+    const percent = Number((row as any).percent);
+    const label = uiString((row as any).label ?? (row as any).title, 32);
+    const resetsAt = uiString((row as any).resetsAt, 40) || fallbackReset;
+    if (!label || !Number.isFinite(percent) || percent < 0) continue;
+    out.push({ label, title: label, percent: Math.max(0, Math.min(1, percent)), resetsAt });
+  }
+  return out;
+}
+export function grokObservedLimits(directory = STATE_DIR): any[] {
+  const liveRaw = readRegularFileLimited(join(directory, GROK_BILLING_FILE), 4096);
+  const live = liveRaw ? parseJsonBounded(liveRaw, 4096, 8) : null;
+  const fromLive = normalizeLimitRows(live && live.limits, uiString(live && live.resetsAt, 40));
+  if (fromLive.length) return fromLive;
+  if (directory === STATE_DIR) {
+    const meters = grokBillingMeters(grokBillingFromUnifiedLog(readHistoryTail(join(process.env.GROK_HOME || join(HOME, ".grok"), "logs", "unified.jsonl"), 64 * 1024) || ""));
+    if (meters.length) return meters;
+  }
+  const raw = readRegularFileLimited(join(directory, "grok-limits.json"), 4096);
+  if (!raw) return [];
+  const parsed = parseJsonBounded(raw, 4096, 8);
+  return normalizeLimitRows(parsed && typeof parsed === "object" ? parsed.limits : []);
+}
+export function withGrokObservedLimits(record: any, directory = STATE_DIR): any {
+  const limits = grokObservedLimits(directory);
+  if (!limits.length) return record;
+  return {
+    ...record,
+    limits,
+    tierLabel: "weekly",
+    usageStatusText: "weekly pool from Grok billing, plus local " + (record.hasTokenData ? "token totals" : "session counts"),
+  };
+}
+const MAX_GROK_USAGE_SESSIONS = 256;
+const MAX_GROK_UPDATE_TAIL = 512 * 1024;
+const MAX_OPENCODE_USAGE_ROWS = 20_000;
+let currentGrokUsageCache: any = null;
+let currentOpencodeUsageCache: any = null;
+
+function nToken(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? n : 0;
+}
+function addTokenUsage(into: TokenUsage, add: TokenUsage): void {
+  into.inputTokens += add.inputTokens;
+  into.outputTokens += add.outputTokens;
+  into.cacheReadInputTokens += add.cacheReadInputTokens;
+  into.cacheCreationInputTokens += add.cacheCreationInputTokens;
+}
+function tokenTotal(u: TokenUsage): number {
+  return u.inputTokens + u.outputTokens + u.cacheReadInputTokens + u.cacheCreationInputTokens;
+}
+export type GrokUsageSnap = { ts: number; usage: TokenUsage; models: Record<string, TokenUsage> };
+function grokTokenFields(raw: any): TokenUsage | null {
+  if (!raw || typeof raw !== "object") return null;
+  const usage: TokenUsage = {
+    inputTokens: nToken(raw.inputTokens),
+    outputTokens: nToken(raw.outputTokens) + nToken(raw.reasoningTokens),
+    cacheReadInputTokens: nToken(raw.cachedReadTokens),
+    cacheCreationInputTokens: nToken(raw.cacheCreationTokens),
+  };
+  return tokenTotal(usage) > 0 ? usage : null;
+}
+export function grokUsageFromUpdate(value: any, fallbackTs = 0): GrokUsageSnap | null {
+  const stack: any[] = [value];
+  const candidates: any[] = [];
+  let steps = 0;
+  while (stack.length && steps++ < 128) {
+    const item = stack.pop();
+    if (!item || typeof item !== "object") continue;
+    if (!Array.isArray(item) && Number.isFinite(Number(item.inputTokens)) && Number.isFinite(Number(item.outputTokens)))
+      candidates.push(item);
+    const children = Array.isArray(item) ? item : Object.values(item);
+    for (const child of children.slice(0, 24)) stack.push(child);
+  }
+  const usage = candidates.find(item => item.modelUsage && typeof item.modelUsage === "object") || candidates[candidates.length - 1];
+  const totals = grokTokenFields(usage);
+  if (!totals) return null;
+  const models: Record<string, TokenUsage> = {};
+  const rawModels = usage.modelUsage && typeof usage.modelUsage === "object" ? usage.modelUsage : {};
+  for (const [name, raw] of Object.entries(rawModels).slice(0, 16)) {
+    const model = grokTokenFields(raw);
+    const key = uiString(name, 64);
+    if (model && key) models[key] = model;
+  }
+  if (!Object.keys(models).length) models.grok = totals;
+  const ts = stampOfUpdate(value) || fallbackTs;
+  return { ts, usage: totals, models };
+}
+function stampOfUpdate(value: any): number {
+  const raw = value && typeof value === "object" ? value.timestamp : 0;
+  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) return raw > 1e12 ? raw : raw * 1000;
+  const parsed = Date.parse(String(raw || ""));
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+export function grokUsageFromUpdatesText(text: string): GrokUsageSnap[] {
+  const snaps: GrokUsageSnap[] = [];
+  for (const line of String(text || "").split("\n")) {
+    if (!line.includes("inputTokens")) continue;
+    const parsed = parseJsonBounded(line, 2048, 12);
+    const snap = grokUsageFromUpdate(parsed);
+    if (snap) snaps.push(snap);
+  }
+  return snaps.length > 256 ? snaps.slice(-256) : snaps;
+}
+export function foldGrokSessionSnaps(snaps: GrokUsageSnap[]): { last: GrokUsageSnap | null; daily: Map<string, number> } {
+  const daily = new Map<string, number>();
+  if (!snaps.length) return { last: null, daily };
+  const ordered = snaps.slice().sort((a, b) => a.ts - b.ts);
+  let previous = 0;
+  for (const snap of ordered) {
+    const total = tokenTotal(snap.usage);
+    const delta = total - previous;
+    if (delta > 0 && snap.ts) {
+      const day = localDayKey(snap.ts);
+      daily.set(day, (daily.get(day) || 0) + delta);
+    }
+    previous = total;
+  }
+  return { last: ordered[ordered.length - 1], daily };
+}
+function localUsageRecord(fields: {
+  name: string; todayPrompts: number; todaySessions: number; todayTotalTokens: number;
+  totalPrompts: number; totalSessions: number;
+  modelUsage: Record<string, TokenUsage>; todayTokensByModel: Record<string, number>;
+  recentDays: Array<{ date: string; messageCount: number }>;
+}): any {
+  return normalizeUsage({
+    name: fields.name, ready: true, tierLabel: "local", limits: [],
+    usageStatusText: LOCAL_USAGE_STATUS,
+    todayPrompts: fields.todayPrompts, todaySessions: fields.todaySessions, todayTotalTokens: fields.todayTotalTokens,
+    totalPrompts: fields.totalPrompts, totalSessions: fields.totalSessions, updatedAt: now,
+    modelUsage: fields.modelUsage, todayTokensByModel: fields.todayTokensByModel, recentDays: fields.recentDays,
+  });
+}
+function grokLocalUsage(): any | null {
+  const base = process.env.GROK_HOME || join(HOME, ".grok");
+  const root = join(base, "sessions");
+  const files: string[] = [];
+  for (const group of ls(root).slice(0, MAX_COLLECTION_ITEMS)) {
+    const groupPath = join(root, group);
+    try { const state = lstatSync(groupPath); if (state.isSymbolicLink() || !state.isDirectory()) continue; } catch { continue; }
+    for (const entry of ls(groupPath).slice(0, MAX_COLLECTION_ITEMS)) {
+      if (!cleanSessionId(entry)) continue;
+      const updates = join(groupPath, entry, "updates.jsonl");
+      try {
+        const state = lstatSync(updates);
+        if (state.isSymbolicLink() || !state.isFile()) continue;
+        files.push(updates);
+      } catch { continue; }
+      if (files.length >= MAX_GROK_USAGE_SESSIONS) break;
+    }
+    if (files.length >= MAX_GROK_USAGE_SESSIONS) break;
+  }
+  if (!files.length) return null;
+  const identity = files.map(path => {
+    try { const state = lstatSync(path); return `${path}:${state.size}:${Math.round(state.mtimeMs)}`; } catch { return path; }
+  }).join("|");
+  // Billing is attached after selecting the local record, including cache hits.
+  const hashed = String(Bun.hash(identity + "|" + localDayKey(now)));
+  const cached = prev.grokLocalUsage && prev.grokLocalUsage.identity === hashed ? prev.grokLocalUsage : null;
+  if (!FORCE_REFRESH && cached?.record) { currentGrokUsageCache = cached; return cached.record; }
+  const modelUsage: Record<string, TokenUsage> = {};
+  const todayTokensByModel: Record<string, number> = {};
+  const daily = new Map<string, number>();
+  const sessions = new Set<string>();
+  const todaySessions = new Set<string>();
+  const today = localDayKey(now);
+  for (const path of files) {
+    const text = readRegularFileTail(path, MAX_GROK_UPDATE_TAIL) || readRegularFileLimited(path, MAX_GROK_UPDATE_TAIL);
+    const folded = foldGrokSessionSnaps(grokUsageFromUpdatesText(text || ""));
+    if (!folded.last) continue;
+    sessions.add(path);
+    for (const [model, usage] of Object.entries(folded.last.models)) {
+      const bucket = modelUsage[model] || (modelUsage[model] = { inputTokens: 0, outputTokens: 0, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 });
+      addTokenUsage(bucket, usage);
+    }
+    for (const [day, tokens] of folded.daily) daily.set(day, (daily.get(day) || 0) + tokens);
+    if (folded.daily.get(today)) todaySessions.add(path);
+  }
+  if (!sessions.size) return null;
+  const dayKeys = heatDays.map(localDayKey);
+  const todayTotalTokens = daily.get(today) || 0;
+  const record = localUsageRecord({
+    name: "Grok",
+    todayPrompts: counts.grok?.today || 0, todaySessions: todaySessions.size, todayTotalTokens,
+    totalPrompts: counts.grok?.total || 0, totalSessions: sessions.size,
+    modelUsage, todayTokensByModel,
+    recentDays: dayKeys.map(date => ({ date, messageCount: daily.get(date) || 0 })),
+  });
+  currentGrokUsageCache = { identity: hashed, record };
+  return record;
+}
+export function sqliteUsageIdentity(path: string, stamp = now): string | null {
+  try {
+    const stat = lstatSync(path, { bigint: true });
+    if (!stat.isFile()) return null;
+    const fileKey = (s: typeof stat) => `${s.dev}:${s.ino}:${s.size}:${s.mtimeNs}:${s.ctimeNs}`;
+    let wal = "absent";
+    try {
+      const state = lstatSync(path + "-wal", { bigint: true });
+      if (!state.isFile()) return null;
+      wal = fileKey(state);
+    } catch (error: any) {
+      if (error?.code !== "ENOENT") return null;
+    }
+    // WAL commits need not touch the database file. Date-sensitive totals
+    // also expire at local midnight even when neither file has changed.
+    return `${localDayKey(stamp)}|${fileKey(stat)}|${wal}`;
+  } catch { return null; }
+}
+function opencodeLocalUsage(): any | null {
+  const dataRoot = process.env.XDG_DATA_HOME || join(HOME, ".local/share");
+  const path = join(dataRoot, "opencode/opencode.db");
+  const identity = sqliteUsageIdentity(path);
+  if (!identity) return null;
+  const cached = prev.opencodeLocalUsage && prev.opencodeLocalUsage.identity === identity ? prev.opencodeLocalUsage : null;
+  if (!FORCE_REFRESH && cached?.record) { currentOpencodeUsageCache = cached; return cached.record; }
+  let db: Database | null = null;
+  try {
+    db = new Database(path, { readonly: true });
+    const rows = db.query(`
+      SELECT session_id AS session, time_created AS ts,
+        json_extract(data, '$.modelID') AS model,
+        json_extract(data, '$.tokens.input') AS input,
+        json_extract(data, '$.tokens.output') AS output,
+        json_extract(data, '$.tokens.reasoning') AS reasoning,
+        json_extract(data, '$.tokens.cache.read') AS cache_read,
+        json_extract(data, '$.tokens.cache.write') AS cache_write
+      FROM message
+      WHERE json_valid(data) AND json_extract(data, '$.role') = 'assistant'
+      LIMIT ${MAX_OPENCODE_USAGE_ROWS}
+    `).all() as any[];
+    const modelUsage: Record<string, TokenUsage> = {};
+    const todayTokensByModel: Record<string, number> = {};
+    const daily = new Map<string, number>();
+    const sessions = new Set<string>();
+    const todaySessions = new Set<string>();
+    const today = localDayKey(now);
+    let todayTotalTokens = 0;
+    for (const row of rows) {
+      const usage: TokenUsage = {
+        inputTokens: nToken(row.input),
+        outputTokens: nToken(row.output) + nToken(row.reasoning),
+        cacheReadInputTokens: nToken(row.cache_read),
+        cacheCreationInputTokens: nToken(row.cache_write),
+      };
+      const total = tokenTotal(usage);
+      if (total <= 0) continue;
+      const model = uiString(row.model, 64) || "opencode";
+      const bucket = modelUsage[model] || (modelUsage[model] = { inputTokens: 0, outputTokens: 0, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 });
+      addTokenUsage(bucket, usage);
+      sessions.add(String(row.session || ""));
+      const ts = Number(row.ts || 0);
+      const day = ts > 0 ? localDayKey(ts) : "";
+      if (day) daily.set(day, (daily.get(day) || 0) + total);
+      if (day === today) {
+        todayTotalTokens += total;
+        todayTokensByModel[model] = (todayTokensByModel[model] || 0) + total;
+        todaySessions.add(String(row.session || ""));
+      }
+    }
+    if (!sessions.size) return null;
+    const dayKeys = heatDays.map(localDayKey);
+    const record = localUsageRecord({
+      name: "opencode",
+      todayPrompts: counts.opencode?.today || 0, todaySessions: todaySessions.size, todayTotalTokens,
+      totalPrompts: counts.opencode?.total || 0, totalSessions: [...sessions].filter(Boolean).length,
+      modelUsage, todayTokensByModel,
+      recentDays: dayKeys.map(date => ({ date, messageCount: daily.get(date) || 0 })),
+    });
+    currentOpencodeUsageCache = { identity, record };
+    return record;
+  } catch { return null; }
+  finally { try { db?.close(); } catch {} }
+}
+const CLAUDE_AUTH_REFRESH_MS = 15 * 60 * 1000;
+let currentClaudeAuthRefreshAt = Number(prev.claudeAuthRefreshAt || 0);
+let claudeUsageFresh: any = null;
+
+export function claudeOauthExpiredAt(expiresAt: unknown, nowMs = now): boolean {
+  const n = Number(expiresAt);
+  return Number.isFinite(n) && n > 0 && n <= nowMs;
+}
+
+function claudeOauthExpired(): boolean {
+  const path = join(process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude"), ".credentials.json");
+  let fd = -1;
+  try {
+    fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+    const st = fstatSync(fd);
+    const uid = typeof process.getuid === "function" ? process.getuid() : -1;
+    if (!st.isFile() || st.nlink !== 1 || (uid >= 0 && st.uid !== uid) || (st.mode & 0o077) || st.size > 16_384) return false;
+    const buf = Buffer.allocUnsafe(st.size);
+    const n = readSync(fd, buf, 0, buf.byteLength, 0);
+    const parsed = parseJsonBounded(buf.subarray(0, n).toString("utf8"), 16_384, 8);
+    const oauth = parsed && typeof parsed === "object" ? (parsed as any).claudeAiOauth : null;
+    if (!oauth || typeof oauth !== "object") return false;
+    return claudeOauthExpiredAt(oauth.expiresAt);
+  } catch { return false; }
+  finally { if (fd >= 0) try { closeSync(fd); } catch {} }
+}
+
+async function refreshClaudeAuthIfNeeded() {
+  try {
+    if (process.env.INFOMARCHY_SKIP_CLAUDE_USAGE === "1") return;
+    if (!FORCE_REFRESH && instanceId() === "overlay") return;
+    const expired = claudeOauthExpired();
+    if (!FORCE_REFRESH && !expired) return;
+    if (expired) {
+      if (!FORCE_REFRESH && currentClaudeAuthRefreshAt && now - currentClaudeAuthRefreshAt < CLAUDE_AUTH_REFRESH_MS) return;
+      const claude = Bun.which("claude");
+      if (!claude) return;
+      currentClaudeAuthRefreshAt = now;
+      await run([claude, "-p", "ping", "--max-turns", "0", "--output-format", "json"], 12_000);
+    }
+    const collector = join(process.env.OMARCHY_PATH || "/usr/share/omarchy", "bin/omarchy-agent-usage-claude");
+    if (!existsSync(collector)) return;
+    const text = await run([collector, "--limits-only"], 8_000);
+    const parsed = parseJsonBounded(text, 4000, 12);
+    if (parsed && typeof parsed === "object" && parsed.id === "claude") claudeUsageFresh = parsed;
+  } catch {}
+}
+
 // Grok publishes no usage cache the way Claude and Codex do: Omarchy ships no
 // collector for it, it bills credits rather than rate-limit windows, and
 // `/usage` opens billing in a browser. What it does keep on disk is one
@@ -2269,7 +2756,7 @@ export function grokSessionUsage(base: string): { sessions: number; todaySession
 function grokUsage() {
   const base = process.env.GROK_HOME || join(HOME, ".grok");
   if (!existsSync(base)) return null;
-  const { sessions, todaySessions, models, modelSessions } = grokSessionUsage(base);
+  const { sessions, todaySessions, modelSessions } = grokSessionUsage(base);
   const prompts = counts.grok || { today: 0, week: 0, total: 0 };
   return normalizeUsage({
     name: "Grok",
@@ -2299,11 +2786,17 @@ function agentsUsage() {
     const j = text === null ? null : parseJsonBounded(text, 4000, 12);
     if (!j || typeof j !== "object") continue;
     const key = uiString(f.replace(/\.json$/, ""), 32);
-    if (key) out[key] = normalizeUsage(j);
+    if (!key) continue;
+    out[key] = key === "claude" && claudeUsageFresh ? normalizeUsage(claudeUsageFresh) : normalizeUsage(j);
   }
-  // Only when Omarchy has not grown a collector of its own; a real cache is
-  // always better than what can be inferred from the session directories.
-  if (!out.grok) { const grok = grokUsage(); if (grok) out.grok = grok; }
+  // Omarchy does not ship grok or opencode collectors. Fill those rows from
+  // local session files. Never write into Omarchy's usage directory, and never
+  // replace a record Omarchy already produced.
+  if (!out.grok) {
+    const grok = grokLocalUsage() || grokUsage();
+    if (grok) out.grok = withGrokObservedLimits(grok);
+  }
+  if (!out.opencode) { const oc = opencodeLocalUsage(); if (oc) out.opencode = oc; }
   return out;
 }
 
@@ -2456,7 +2949,7 @@ async function runCollector() {
   }
   const pids = scanProcs();
   const [cpuS, memS, diskS, netS, pingS, gpuS, sessions, ollama, externalIpS, github] = await Promise.all([
-    Promise.resolve(cpu()), Promise.resolve(mem()), disk(), net(), ping(), gpu(), liveSessions(pids), ollamaState(), externalIp(), githubActivity(),
+    Promise.resolve(cpu()), Promise.resolve(mem()), disk(), net(), ping(), gpu(), liveSessions(pids), ollamaState(), externalIp(), githubActivity(), refreshGrokBilling(), refreshClaudeAuthIfNeeded(),
   ]);
   const claude = claudeHistory(), codex = codexHistory(), grok = grokHistory(), grokBot = grokBotHistory(), opencode = opencodeHistory(), pi = piHistory(), hermes = hermesHistory();
   recent.sort((a, b) => b.ts - a.ts);
@@ -2509,6 +3002,9 @@ async function runCollector() {
       topicSummaries,
       ciByRepo: currentCiByRepo,
       opencodeTotals: currentOpencodeTotals,
+      grokLocalUsage: currentGrokUsageCache,
+      opencodeLocalUsage: currentOpencodeUsageCache,
+      claudeAuthRefreshAt: currentClaudeAuthRefreshAt,
       sessionNotifications: notificationState.tracked,
     }));
   } catch {}

--- a/info-ui.test.ts
+++ b/info-ui.test.ts
@@ -110,6 +110,9 @@ describe("usage trend chart", () => {
     expect(view).toContain("readonly property var usageSeries");
     expect(view).toContain("id: trendCanvas");
     expect(view).toContain('text: view.usageMetric === "value" ? "≈ $ VALUE" : "TOKENS"');
+    expect(view).toContain("up.u.usageStatusText");
+    expect(view).toContain("color: Util.alpha(up.tone, 0.07)");
+    expect(view).toContain("border.color: Util.alpha(up.tone, 0.28)");
     expect(view).toContain("usageTrend.hovered");
     expect(view).toContain('"% cache reads"');
     expect(view).toContain('"unpriced"');
@@ -507,4 +510,17 @@ test("media selection prefers playback and skips playerctld when another player 
   expect(choose({ mprisPlayers: [proxy, paused], mediaIsProxy })).toBe(paused);
   expect(choose({ mprisPlayers: [proxy], mediaIsProxy })).toBe(proxy);
   expect(choose({ mprisPlayers: [], mediaIsProxy })).toBeNull();
+});
+
+describe("hard refresh", () => {
+  test("HARD REFRESH is the first module-strip control and forces a collector pass", () => {
+    const strip = view.slice(view.indexOf("id: moduleStrip"), view.indexOf("id: leftColumn"));
+    expect(strip.indexOf("HARD REFRESH")).toBeGreaterThan(-1);
+    expect(strip.indexOf("HARD REFRESH")).toBeLessThan(strip.indexOf("Repeater {"));
+    expect(view).toContain("onClicked: view.desk.hardRefresh()");
+    expect(model).toContain("function hardRefresh()");
+    expect(model).toContain('cmd.push("--force-refresh")');
+    expect(service).toContain("function hardRefresh(): void { infoModel.hardRefresh() }");
+    expect(overlay).toContain("function hardRefresh() { infoModel.hardRefresh() }");
+  });
 });

--- a/qml-resolve.test.ts
+++ b/qml-resolve.test.ts
@@ -22,12 +22,14 @@ import { join } from "path";
 // A ceiling still catches the case that matters: one new unresolvable
 // reference moves the count, which is exactly what a bad merge introduces.
 // Verified — the same injection took InfoModel from 5 to 6.
+// Usage adds the refresh chip and provider-block bindings; retain a bounded
+// baseline for dynamic Style properties and unqualified QML accesses.
 const CEILINGS: Record<string, number> = {
   "BackgroundWallpaper.qml": 2,
   "Infomarchy.qml": 26,
   "InfoModel.qml": 5,
   "InfoSettings.qml": 0,
-  "InfoView.qml": 473,
+  "InfoView.qml": 479,
   "Overlay.qml": 29,
   "WaveWallpaper.qml": 0,
 };


### PR DESCRIPTION
This brings the desktop usage improvements from my fork into one independently reviewable group.

Grok and OpenCode can populate USAGE from local session tokens when Omarchy has no record. Grok's observed weekly billing is independent of whether session token snapshots exist. OpenCode cache invalidation includes WAL commits and local midnight. Provider rows have separate tinted borders while retaining upstream's per-model meters.

The first strip chip, HARD REFRESH, bypasses supported caches and re-reads Claude limits. Expired Claude OAuth can be refreshed by the installed CLI with a 15-minute backoff; stale sign-in help is hidden after successful limits. Grok billing uses a shared 60-second cache, failure backoff, and descriptor-held flock to prevent overlapping requests. Credentials stay out of argv, redirects are refused, and the existing skip switches remain authoritative. Infomarchy never writes Omarchy's usage records.

Validation on upstream `9726812` (1.4.1): `PATH=/usr/bin:$PATH bun test --timeout 30000` passed 243 tests across 15 files, including both QML syntax and real-import resolution gates. `git diff --check` passed. The explicit PATH makes isolated-HOME collector fixtures use the installed Bun binary.

Retained the upstream Ollama origin binding and GitHub skip helper. The Grok cumulative-token fixture uses a single UTC day to avoid midnight/timezone-dependent failures.

This targets upstream master directly and includes no Web Mode listener, tokens, snapshot publishing, settings panel, or fork identity changes.
