### PR TITLE
feat: add an optional containers card with start and stop controls

### DIFF
--- a/InfoModel.qml
+++ b/InfoModel.qml
@@ -21,6 +21,7 @@ Item {
   property string sessionActionsPath: Qt.resolvedUrl("session-actions.ts").toString().replace(/^file:\/\//, "")
   property string copyTextPath: Qt.resolvedUrl("copy-text.ts").toString().replace(/^file:\/\//, "")
   property string ollamaControlPath: Qt.resolvedUrl("ollama-control.ts").toString().replace(/^file:\/\//, "")
+  property string containerControlPath: Qt.resolvedUrl("container-control.ts").toString().replace(/^file:\/\//, "")
   property string previewPath: Qt.resolvedUrl("window-preview.ts").toString().replace(/^file:\/\//, "")
   property string herdrFocusPath: Qt.resolvedUrl("herdr-focus.ts").toString().replace(/^file:\/\//, "")
   property string stopPath: Qt.resolvedUrl("stop-session.ts").toString().replace(/^file:\/\//, "")
@@ -34,6 +35,11 @@ Item {
   property string ollamaError: ""
   property string ollamaModel: ""
   property string ollamaAction: ""
+  property bool containerBusy: false
+  property string containerStatus: ""
+  property string containerError: ""
+  property string containerName: ""
+  property string containerAction: ""
   // Omarchy does not ship bun (verified against omarchy-base.packages and
   // omarchy-other.packages, 2026-09-04). Without it every helper here is dead
   // and the desk used to sit on "collecting…" forever with a one-word hint.
@@ -513,6 +519,57 @@ Item {
         root.ollamaStatus = ""
       }
       root.ollamaBusy = false
+      root.refresh()
+    }
+  }
+
+  function controlContainer(action, name) {
+    var operation = String(action || ""), id = String(name || "")
+    if (root.containerBusy || ["start", "stop"].indexOf(operation) < 0 || !/^[A-Za-z0-9][A-Za-z0-9_.-]{0,254}$/.test(id)) return false
+    root.containerBusy = true
+    root.containerAction = operation
+    root.containerName = id
+    root.containerError = ""
+    root.containerStatus = (operation === "start" ? "starting " : "stopping ") + id + "…"
+    containerProcess.pendingFrame = ({ action: operation, name: id })
+    containerProcess.running = true
+    return true
+  }
+
+  function acceptContainerResult(raw) {
+    var result
+    try { result = JSON.parse(String(raw || "")) } catch (e) { result = null }
+    containerProcess.responded = true
+    if (!result || result.ok !== true) {
+      root.containerError = root.plainText(result && result.message ? result.message : "Invalid container control response", 160)
+      root.containerStatus = ""
+      return
+    }
+    root.containerError = ""
+    root.containerStatus = root.plainText(result.message || "Container updated", 160)
+  }
+
+  Process {
+    id: containerProcess
+    property var pendingFrame: ({})
+    property bool responded: false
+    command: ["bun", root.containerControlPath]
+    stdinEnabled: true
+    onRunningChanged: if (running) responded = false
+    onStarted: {
+      write(JSON.stringify(pendingFrame) + "\n")
+      pendingFrame = ({})
+    }
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.acceptContainerResult(text)
+    }
+    onExited: function(exitCode) {
+      if (!responded) {
+        root.containerError = "Container control helper exited " + exitCode
+        root.containerStatus = ""
+      }
+      root.containerBusy = false
       root.refresh()
     }
   }

--- a/InfoSettings.qml
+++ b/InfoSettings.qml
@@ -20,7 +20,8 @@ Item {
     { id: "machine", label: "MACHINE" },
     { id: "changes", label: "CHANGES" },
     { id: "projects", label: "PROJECTS" },
-    { id: "media", label: "MEDIA" }
+    { id: "media", label: "MEDIA" },
+    { id: "containers", label: "CONTAINERS" }
   ]
   property var sections: ({})
   property var attentionMuted: ({})
@@ -39,11 +40,11 @@ Item {
   // restart from briefly re-enabling a dashboard the user turned off.
   property bool ready: false
   property bool dashboardVisible: false
-  property var rightOrder: ["usage", "localAi", "machine", "media"]
+  property var rightOrder: ["usage", "localAi", "machine", "media", "containers"]
   property var opsOrder: ["changes", "needs", "projects"]
 
   function normalizedRightOrder(value) {
-    var allowed = ["usage", "localAi", "machine", "media"], result = []
+    var allowed = ["usage", "localAi", "machine", "media", "containers"], result = []
     if (Array.isArray(value)) for (var i = 0; i < value.length; i++) if (allowed.indexOf(value[i]) >= 0 && result.indexOf(value[i]) < 0) result.push(value[i])
     for (var j = 0; j < allowed.length; j++) if (result.indexOf(allowed[j]) < 0) result.push(allowed[j])
     return result

--- a/InfoView.qml
+++ b/InfoView.qml
@@ -118,6 +118,8 @@ Item {
     }
     return playing || any || proxy
   }
+
+  readonly property var containers: snap.containers || ({})
   readonly property var ai: snap.ai || ({})
   readonly property var allSessions: ai.sessions || []
   readonly property var projects: ai.projects || []
@@ -766,6 +768,30 @@ Item {
     implicitWidth: tl.implicitWidth + Style.spacing.md * 2
     implicitHeight: tl.implicitHeight + Style.spacing.xs * 2
     PlainText { id: tl; anchors.centerIn: parent; text: parent.text; color: tone; font.family: view.mono; font.pixelSize: Style.font.caption; font.bold: true }
+  }
+
+  component PowerToggle: Item {
+    id: tog
+    property bool lit: false
+    property bool busy: false
+    implicitWidth: Math.round(40 * Style.fontScale)
+    implicitHeight: Math.round(18 * Style.fontScale)
+    Rectangle {
+      anchors.fill: parent
+      radius: height / 2
+      color: Util.alpha(tog.lit ? view.desk.green : view.desk.themeForeground, tog.lit ? 0.22 : 0.08)
+      border.width: 1
+      border.color: Util.alpha(tog.lit ? view.desk.green : view.desk.themeForeground, tog.lit ? 0.65 : 0.28)
+      Rectangle {
+        width: parent.height - 4
+        height: width
+        radius: width / 2
+        y: 2
+        x: tog.lit ? parent.width - width - 2 : 2
+        color: tog.busy ? view.textFaint : (tog.lit ? view.desk.green : view.textDim)
+        Behavior on x { NumberAnimation { duration: 120; easing.type: Easing.OutCubic } }
+      }
+    }
   }
 
   // A labelled row in ABOUT that opens one of the plugin's own two addresses.
@@ -1476,7 +1502,7 @@ Item {
       // RIGHT COLUMN: usage + local AI + machine corner
       GridLayout {
         id: rightColumn
-        visible: view.sectionEnabled("usage") || view.sectionEnabled("localAi") || view.sectionEnabled("machine") || view.sectionEnabled("media")
+        visible: view.sectionEnabled("usage") || view.sectionEnabled("localAi") || view.sectionEnabled("machine") || view.sectionEnabled("media") || view.sectionEnabled("containers")
         Layout.fillHeight: true
         // A fixed column: content-driven widths let the column drift narrower
         // whenever card text became shrinkable, and rows then overran the border.
@@ -2028,6 +2054,101 @@ Item {
             }
           }
         }
+        Card {
+          id: containersCard
+          Layout.row: view.settings.rightIndex("containers")
+          Layout.column: 0
+          Layout.fillWidth: true
+          visible: view.sectionEnabled("containers")
+          moveId: "containers"
+          draggable: true
+          title: "CONTAINERS"
+          readonly property var pack: view.containers
+          readonly property var items: Array.isArray(pack.items) ? pack.items : []
+          readonly property int visibleLimit: 8
+          hint: !pack.present ? "no container engine" : (String(pack.engine || "docker") + " · " + Number(pack.up || 0) + " up · " + Number(pack.total || items.length))
+          function rowMeta(item) {
+            var parts = []
+            if (item.health) parts.push(item.health)
+            else if (item.state && item.state !== "running") parts.push(item.state)
+            if (item.image) parts.push(item.image)
+            return parts.join(" · ")
+          }
+          function requestToggle(item) {
+            if (!item || !item.name || view.desk.containerBusy) return
+            view.desk.controlContainer(item.running ? "stop" : "start", item.name)
+          }
+          ColumnLayout {
+            id: containersColumn
+            anchors { left: parent.left; right: parent.right }
+            spacing: Style.spacing.xs
+            Repeater {
+              model: containersCard.items.slice(0, containersCard.visibleLimit)
+              delegate: RowLayout {
+                id: containerRow
+                required property var modelData
+                Layout.fillWidth: true
+                spacing: Style.spacing.sm
+                readonly property bool thisBusy: view.desk.containerBusy && view.desk.containerName === String(modelData.name || "")
+                Rectangle {
+                  width: 8; height: 8; radius: 4
+                  color: modelData.running ? (modelData.health === "unhealthy" ? view.desk.yellow : view.desk.green) : "transparent"
+                  border.width: modelData.running ? 0 : 1
+                  border.color: view.textFaint
+                }
+                PlainText {
+                  text: modelData.label || modelData.name || ""
+                  color: view.desk.themeForeground
+                  font.family: view.mono
+                  font.pixelSize: Style.font.bodySmall
+                  Layout.fillWidth: true
+                  Layout.minimumWidth: 0
+                  elide: Text.ElideRight
+                }
+                PlainText {
+                  text: containerRow.thisBusy ? (view.desk.containerAction === "stop" ? "stopping" : "starting") : containersCard.rowMeta(modelData)
+                  color: containerRow.thisBusy ? view.desk.yellow : view.textDim
+                  font.family: view.mono
+                  font.pixelSize: Style.font.caption
+                  elide: Text.ElideLeft
+                  horizontalAlignment: Text.AlignRight
+                  Layout.fillWidth: true
+                  Layout.minimumWidth: 0
+                  Layout.maximumWidth: Math.round(140 * Style.fontScale)
+                }
+                PowerToggle {
+                  lit: !!modelData.running
+                  busy: containerRow.thisBusy
+                  opacity: view.desk.containerBusy && !containerRow.thisBusy ? 0.45 : 1
+                  MouseArea {
+                    anchors.fill: parent
+                    enabled: view.interactive && !view.desk.containerBusy
+                    cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                    onClicked: containersCard.requestToggle(containerRow.modelData)
+                  }
+                }
+              }
+            }
+            PlainText {
+              visible: containersCard.items.length === 0
+              text: containersCard.pack.present ? "no containers" : "docker / podman not found"
+              color: view.textFaint
+              font.family: view.mono
+              font.pixelSize: Style.font.bodySmall
+            }
+            PlainText {
+              visible: containersCard.items.length > containersCard.visibleLimit
+              text: "+" + (containersCard.items.length - containersCard.visibleLimit) + " more"
+              color: view.textFaint
+              font.family: view.mono
+              font.pixelSize: Style.font.caption
+            }
+            PlainText { Layout.fillWidth: true; visible: !!view.desk.containerStatus; text: view.desk.containerStatus; color: view.desk.green; font.family: view.mono; font.pixelSize: Style.font.caption; wrapMode: Text.Wrap }
+            PlainText { Layout.fillWidth: true; visible: !!view.desk.containerError; text: view.desk.containerError; color: view.desk.red; font.family: view.mono; font.pixelSize: Style.font.caption; wrapMode: Text.Wrap }
+          }
+        }
+
+
         // Legend — readable, one line, under the last card. Wording follows the
         // surface. The version sits at the far end: present on every screen,
         // never in the way of the data, and the way into ABOUT.

--- a/README.md
+++ b/README.md
@@ -264,6 +264,10 @@ Still and animated image wallpapers share one image surface. Supported animated 
 A hideable, reorderable MEDIA CONTROLS card uses the local MPRIS service for title, artist, album, player identity, and previous/play-pause/next actions. A playing player is preferred, and playerctld is used only when no other player exists. Metadata is bounded plain text; album art is never fetched. Demo mode shows sample metadata and disables actions.
 Pi sessions are detected from the `pi` process and `~/.pi/agent/sessions` JSONL history. Recent Tasks includes Pi prompts, activity, and resume via `pi --session <id>`. The recent-task window reserves space for quieter providers while retaining pinned-first and newest-first display order.
 
+### Containers
+
+An optional CONTAINERS card joins the right column, with Docker (`/usr/bin/docker`) preferred over Podman. It shows up to eight rows and explicit start/stop toggles. Each action checks a fresh `ps -a` inventory and passes the matched name as a separate argument. The bounded snapshot retains only id, name, display label, compose service/project, short image, state, running status and health; it excludes compose working directories, env files, commands, mounts and ports. Hide/reorder the card through the existing module controls; `INFOMARCHY_SKIP_CONTAINERS=1` skips collection.
+
 ## FAQ
 
 **Does it drain my battery?** One `bun` run every 4 s (~0.2 s of CPU warm), no idle animation except the busy-dot pulse — a few percent of one core at most. Raise `refreshMs` if you want it lower.

--- a/collector.test.ts
+++ b/collector.test.ts
@@ -355,8 +355,8 @@ describe("prev.json instance files", () => {
     writeFileSync(join(fixture, "keep"), "");
 
     async function collect(id: string) {
-      const proc = Bun.spawn(["bun", join(import.meta.dir, "collector.ts"), "--id", id], {
-        env: { HOME: fixture, USER: "tester", XDG_STATE_HOME: state, PATH: process.env.PATH || "", INFOMARCHY_SKIP_EXTERNAL_IP: "1" },
+      const proc = Bun.spawn([process.execPath, join(import.meta.dir, "collector.ts"), "--id", id], {
+        env: { HOME: fixture, USER: "tester", XDG_STATE_HOME: state, PATH: process.env.PATH || "", INFOMARCHY_SKIP_EXTERNAL_IP: "1", INFOMARCHY_SKIP_CONTAINERS: "1" },
         stdout: "pipe",
         stderr: "pipe",
       });
@@ -395,8 +395,8 @@ describe("history collection", () => {
       JSON.stringify({ timestamp, session_id: "session-b", prompt: "use ntn_abcdefghijklmnopqrstuvwxyz", is_bash: false }),
     ].join("\n"));
 
-    const proc = Bun.spawn(["bun", join(import.meta.dir, "collector.ts")], {
-      env: { HOME: historyFixture, USER: "tester", XDG_STATE_HOME: join(historyFixture, "state"), PATH: process.env.PATH || "", INFOMARCHY_SKIP_EXTERNAL_IP: "1" },
+    const proc = Bun.spawn([process.execPath, join(import.meta.dir, "collector.ts")], {
+      env: { HOME: historyFixture, USER: "tester", XDG_STATE_HOME: join(historyFixture, "state"), PATH: process.env.PATH || "", INFOMARCHY_SKIP_EXTERNAL_IP: "1", INFOMARCHY_SKIP_CONTAINERS: "1" },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -431,8 +431,8 @@ describe("history collection", () => {
 
     const home = join(testRoot, "grok-home-empty");
     mkdirSync(home, { recursive: true });
-    const proc = Bun.spawn(["bun", join(import.meta.dir, "collector.ts")], {
-      env: { HOME: home, USER: "tester", GROK_HOME: root, XDG_STATE_HOME: join(home, "state"), PATH: process.env.PATH || "", INFOMARCHY_SKIP_EXTERNAL_IP: "1" },
+    const proc = Bun.spawn([process.execPath, join(import.meta.dir, "collector.ts")], {
+      env: { HOME: home, USER: "tester", GROK_HOME: root, XDG_STATE_HOME: join(home, "state"), PATH: process.env.PATH || "", INFOMARCHY_SKIP_EXTERNAL_IP: "1", INFOMARCHY_SKIP_CONTAINERS: "1" },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -525,8 +525,8 @@ describe("history collection", () => {
       schemaVersion: 1, value: { entries: [{ kind: "message", role: "user", content: "my private conversation" }] },
     }));
 
-    const proc = Bun.spawn(["bun", join(import.meta.dir, "collector.ts")], {
-      env: { HOME: root, USER: "tester", XDG_STATE_HOME: join(root, "state"), PATH: process.env.PATH || "", INFOMARCHY_SKIP_EXTERNAL_IP: "1" },
+    const proc = Bun.spawn([process.execPath, join(import.meta.dir, "collector.ts")], {
+      env: { HOME: root, USER: "tester", XDG_STATE_HOME: join(root, "state"), PATH: process.env.PATH || "", INFOMARCHY_SKIP_EXTERNAL_IP: "1", INFOMARCHY_SKIP_CONTAINERS: "1" },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -556,8 +556,8 @@ describe("history collection", () => {
     db.query("INSERT INTO part VALUES (?, ?, ?, ?, ?)").run("part_1", "msg_1", "ses_test12345", Date.now(), JSON.stringify({ type: "text", text: "inspect with password: very-secret-value" }));
     db.close();
 
-    const proc = Bun.spawn(["bun", join(import.meta.dir, "collector.ts")], {
-      env: { HOME: root, USER: "tester", XDG_DATA_HOME: data, XDG_STATE_HOME: join(root, "state"), PATH: process.env.PATH || "", INFOMARCHY_SKIP_EXTERNAL_IP: "1" },
+    const proc = Bun.spawn([process.execPath, join(import.meta.dir, "collector.ts")], {
+      env: { HOME: root, USER: "tester", XDG_DATA_HOME: data, XDG_STATE_HOME: join(root, "state"), PATH: process.env.PATH || "", INFOMARCHY_SKIP_EXTERNAL_IP: "1", INFOMARCHY_SKIP_CONTAINERS: "1" },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -832,9 +832,9 @@ describe("second-reviewer findings (2026-09-04)", () => {
     for (let i = 0; i < 1100; i++) lines.push(JSON.stringify({ timestamp: base - i * 1000, display: "prompt " + i + " " + "words ".repeat(40), project: "/proj/" + (i % 7), sessionId: "aaaaaaaa-bbbb-cccc-dddd-" + String(100000000000 + i) }));
     writeFileSync(join(home, ".claude", "history.jsonl"), lines.join("\n") + "\n");
     try {
-      const proc = Bun.spawn(["bun", join(import.meta.dir, "collector.ts"), "--id", "bigsnap"], {
+      const proc = Bun.spawn([process.execPath, join(import.meta.dir, "collector.ts"), "--id", "bigsnap"], {
         stdout: "pipe", stderr: "ignore",
-        env: { HOME: home, USER: "tester", XDG_STATE_HOME: join(home, "state"), PATH: process.env.PATH || "", INFOMARCHY_SKIP_EXTERNAL_IP: "1", OLLAMA_HOST: "http://127.0.0.1:9" },
+        env: { HOME: home, USER: "tester", XDG_STATE_HOME: join(home, "state"), PATH: process.env.PATH || "", INFOMARCHY_SKIP_EXTERNAL_IP: "1", INFOMARCHY_SKIP_CONTAINERS: "1", OLLAMA_HOST: "http://127.0.0.1:9" },
       });
       const output = await new Response(proc.stdout).text();
       await proc.exited;
@@ -1320,5 +1320,23 @@ describe("zombie detection", () => {
   test("idleSince is the newest of launch and last prompt", () => {
     expect(sessionStaleness({ startedAt: 1000, topicAt: 5000, hosts: [], window: null }, now).idleSince).toBe(5000);
     expect(sessionStaleness({ startedAt: 7000, topicAt: 0, hosts: [], window: null }, now).idleSince).toBe(7000);
+  });
+});
+
+describe("container snapshot", () => {
+  test("demo data includes a containers card payload without host paths", async () => {
+    const home = join(testRoot, "demo-home");
+    mkdirSync(join(home, "state"), { recursive: true });
+    const proc = Bun.spawn([process.execPath, join(import.meta.dir, "collector.ts"), "--demo"], {
+      env: { HOME: home, USER: "tester", XDG_STATE_HOME: join(home, "state"), PATH: process.env.PATH || "", INFOMARCHY_SKIP_EXTERNAL_IP: "1", INFOMARCHY_SKIP_CONTAINERS: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const output = await new Response(proc.stdout).text();
+    expect(await proc.exited).toBe(0);
+    const snap = decodeFrames(output);
+    expect(snap.containers).toMatchObject({ present: true, engine: "docker", up: 3, total: 4 });
+    expect(snap.containers.items.map((item: any) => item.label)).toEqual(["search", "proxy", "db", "worker"]);
+    expect(JSON.stringify(snap.containers)).not.toContain("/home/");
   });
 });

--- a/collector.ts
+++ b/collector.ts
@@ -17,6 +17,7 @@ import { localDayIndex, localDayStarts } from "./history-time";
 import { githubFetchEnabled, githubRefreshDue, githubRepoFromRemote, githubSnapshot, parseGithubStoreText, refreshGithubActivity } from "./github-activity";
 import { attentionSignal, parseCommitSummary, parseDiffNumstat, parseGitStatus, projectHealth, repoCollisions, workspaceGroups, resourceDelta, limitForecast } from "./ai-ops";
 import { deriveNotificationEvents } from "./notification-events";
+import { containerEngine, containerListArgv, parseContainerList } from "./container-control";
 
 const HOME = process.env.HOME || "/root";
 const XDG_STATE = process.env.XDG_STATE_HOME || join(HOME, ".local/state");
@@ -2052,6 +2053,20 @@ async function ollamaState() {
     modelCount: models.length,
   };
 }
+async function containerState() {
+  if (process.env.INFOMARCHY_SKIP_CONTAINERS === "1")
+    return { present: false, engine: null, items: [], up: 0, total: 0 };
+  const engine = containerEngine();
+  if (!engine) return { present: false, engine: null, items: [], up: 0, total: 0 };
+  const items = parseContainerList(await run(containerListArgv(engine), 1500));
+  return {
+    present: true,
+    engine,
+    items,
+    up: items.filter(item => item.running).length,
+    total: items.length,
+  };
+}
 const MAX_USAGE_FILES = 16;
 const MAX_USAGE_FILE_BYTES = 512 * 1024;
 
@@ -2427,6 +2442,15 @@ function demoSnapshot(stamp = Date.now()) {
       gpu: { name: "NVIDIA RTX 4070", util: 31, memUsed: 3_006_477_312, memTotal: 12_884_901_888, temp: 49 },
       temp: 52, uptime: 186_300, externalIp: "203.0.113.42",
     },
+    containers: {
+      present: true, engine: "docker", up: 3, total: 4,
+      items: [
+        { id: "a1b2c3d4e5f6", name: "lab-search-1", label: "search", service: "search", project: "lab", image: "searxng:latest", state: "running", running: true, health: "healthy" },
+        { id: "b2c3d4e5f6a1", name: "lab-proxy-1", label: "proxy", service: "proxy", project: "lab", image: "traefik:v3", state: "running", running: true, health: "healthy" },
+        { id: "c3d4e5f6a1b2", name: "lab-db-1", label: "db", service: "db", project: "lab", image: "postgres:16", state: "running", running: true, health: "healthy" },
+        { id: "d4e5f6a1b2c3", name: "lab-worker-1", label: "worker", service: "worker", project: "lab", image: "lab-worker", state: "exited", running: false, health: "" },
+      ],
+    },
     ai: {
       sessions, projects: projectHealth(sessions), workspaces: workspaceGroups(sessions), attention: [sessions[1]], collisions: [],
       counts: { claude: { today: 18, week: 96, total: 640 }, codex: { today: 27, week: 144, total: 1102 }, opencode: { today: 11, week: 51, total: 214 } },
@@ -2455,8 +2479,8 @@ async function runCollector() {
     return;
   }
   const pids = scanProcs();
-  const [cpuS, memS, diskS, netS, pingS, gpuS, sessions, ollama, externalIpS, github] = await Promise.all([
-    Promise.resolve(cpu()), Promise.resolve(mem()), disk(), net(), ping(), gpu(), liveSessions(pids), ollamaState(), externalIp(), githubActivity(),
+  const [cpuS, memS, diskS, netS, pingS, gpuS, sessions, ollama, externalIpS, github, containers] = await Promise.all([
+    Promise.resolve(cpu()), Promise.resolve(mem()), disk(), net(), ping(), gpu(), liveSessions(pids), ollamaState(), externalIp(), githubActivity(), containerState(),
   ]);
   const claude = claudeHistory(), codex = codexHistory(), grok = grokHistory(), grokBot = grokBotHistory(), opencode = opencodeHistory(), pi = piHistory(), hermes = hermesHistory();
   recent.sort((a, b) => b.ts - a.ts);
@@ -2484,6 +2508,7 @@ async function runCollector() {
       cpu: { pct: cpuS.pct, load: cpuS.load, cores: cpuS.cores }, mem: memS, disks: diskS, net: netS, ping: pingS,
       battery: battery(), gpu: gpuS, temp: temp(), uptime: uptime(), externalIp: externalIpS.address,
     },
+    containers,
     ai: {
       sessions,
       projects: projectHealth(sessions),

--- a/container-control.test.ts
+++ b/container-control.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+import {
+  containerListArgv,
+  containerMutateArgv,
+  controlContainer,
+  parseContainerList,
+  parseContainerRecord,
+  parseControlRequest,
+  readBoundedInput,
+  validContainerName,
+} from "./container-control";
+
+const dockerLine = JSON.stringify({
+  ID: "a49221833480",
+  Names: "lab-search-1",
+  Image: "ghcr.io/example/searxng:2026.8.29-d226b78bc",
+  State: "running",
+  Status: "Up 18 minutes (healthy)",
+  HealthStatus: "healthy",
+  Command: "evil $(curl)",
+  Mounts: "/home/someone/secret",
+  Ports: "0.0.0.0:8787->80/tcp",
+  Labels: "com.docker.compose.project=lab,com.docker.compose.service=search,com.docker.compose.project.working_dir=/home/someone/Projects/lab,com.docker.compose.project.environment_file=/home/someone/Projects/lab/.env",
+});
+
+describe("container inventory parsing", () => {
+  test("accepts docker newline JSON and drops host paths, commands, ports, and raw labels", () => {
+    const items = parseContainerList(dockerLine + "\n" + JSON.stringify({
+      ID: "deadbeef0123",
+      Names: "lab-worker-1",
+      Image: "lab-worker",
+      State: "exited",
+      Status: "Exited (0) 4 minutes ago",
+      Labels: "com.docker.compose.project=lab,com.docker.compose.service=worker",
+    }));
+    expect(items).toHaveLength(2);
+    expect(items[0]).toMatchObject({
+      id: "a49221833480",
+      name: "lab-search-1",
+      label: "search",
+      service: "search",
+      project: "lab",
+      image: "searxng:2026.8.29-d226b78bc",
+      state: "running",
+      running: true,
+      health: "healthy",
+    });
+    expect(items[1]).toMatchObject({ name: "lab-worker-1", label: "worker", running: false, state: "exited" });
+    const blob = JSON.stringify(items);
+    expect(blob).not.toContain("/home/");
+    expect(blob).not.toContain(".env");
+    expect(blob).not.toContain("$(curl)");
+    expect(blob).not.toContain("8787");
+    expect(blob).not.toContain("working_dir");
+  });
+
+  test("prefixes the compose service when more than one project is present", () => {
+    const items = parseContainerList([
+      JSON.stringify({ ID: "aaaaaaaaaaaa", Names: "one-web-1", Image: "nginx", State: "running", Labels: "com.docker.compose.project=one,com.docker.compose.service=web" }),
+      JSON.stringify({ ID: "bbbbbbbbbbbb", Names: "two-web-1", Image: "nginx", State: "exited", Labels: "com.docker.compose.project=two,com.docker.compose.service=web" }),
+    ].join("\n"));
+    expect(items.map(item => item.label).sort()).toEqual(["one/web", "two/web"]);
+  });
+
+  test("parses podman JSON arrays and object State", () => {
+    const items = parseContainerList(JSON.stringify([{
+      Id: "0123456789abcdef0123456789abcdef",
+      Names: ["web"],
+      Image: "docker.io/library/nginx:latest",
+      State: { Status: "running" },
+      Status: "Up 2 hours",
+      Labels: { "com.docker.compose.project": "demo", "com.docker.compose.service": "web" },
+    }]));
+    expect(items).toEqual([expect.objectContaining({
+      id: "0123456789ab",
+      name: "web",
+      label: "web",
+      image: "nginx:latest",
+      running: true,
+    })]);
+  });
+
+  test("rejects option-shaped names, empty records, and over-budget lists", () => {
+    expect(validContainerName("-evil")).toBe("");
+    expect(validContainerName("../x")).toBe("");
+    expect(validContainerName("ok_name.1")).toBe("ok_name.1");
+    expect(parseContainerRecord({ Names: "-flag", State: "running" })).toBeNull();
+    expect(parseContainerRecord({ Names: "", State: "running" })).toBeNull();
+    const lines = Array.from({ length: 40 }, (_, i) => JSON.stringify({
+      ID: i.toString(16).padStart(12, "0"),
+      Names: "c" + i,
+      Image: "x",
+      State: "exited",
+    }));
+    expect(parseContainerList(lines.join("\n"))).toHaveLength(32);
+  });
+});
+
+describe("container start/stop", () => {
+  test("accepts only start/stop of a sane name", () => {
+    expect(parseControlRequest({ action: "start", name: "lab-search-1" })).toEqual({ action: "start", name: "lab-search-1" });
+    expect(parseControlRequest({ action: "kill", name: "lab-search-1" })).toBeNull();
+    expect(parseControlRequest({ action: "stop", name: "-n" })).toBeNull();
+    expect(parseControlRequest({ action: "stop", name: "a/b" })).toBeNull();
+    expect(containerListArgv("docker")[0]).toBe("/usr/bin/docker");
+    expect(containerMutateArgv("docker", "stop", "lab-search-1")).toEqual(["/usr/bin/docker", "stop", "--", "lab-search-1"]);
+  });
+
+  test("refuses names outside the live inventory and never mutates them", async () => {
+    const calls: string[][] = [];
+    const run = async (argv: string[]) => {
+      calls.push(argv);
+      return { code: 0, stdout: dockerLine };
+    };
+    const result = await controlContainer({ action: "stop", name: "not-listed" }, "docker", run);
+    expect(result).toMatchObject({ ok: false, message: "Container is not in the live inventory" });
+    expect(calls).toEqual([["/usr/bin/docker", "ps", "-a", "--format", "{{json .}}"]]);
+  });
+
+  test("starts and stops through argv after an inventory match", async () => {
+    const calls: string[][] = [];
+    const run = async (argv: string[]) => {
+      calls.push(argv);
+      if (argv.includes("ps")) return { code: 0, stdout: dockerLine };
+      return { code: 0, stdout: "lab-search-1\n" };
+    };
+    expect(await controlContainer({ action: "stop", name: "lab-search-1" }, "docker", run)).toMatchObject({ ok: true, action: "stop" });
+    expect(await controlContainer({ action: "start", name: "lab-search-1" }, "docker", run)).toMatchObject({ ok: true, message: "Already running" });
+    expect(calls).toEqual([
+      ["/usr/bin/docker", "ps", "-a", "--format", "{{json .}}"],
+      ["/usr/bin/docker", "stop", "--", "lab-search-1"],
+      ["/usr/bin/docker", "ps", "-a", "--format", "{{json .}}"],
+    ]);
+  });
+
+  test("bounds stdin frames and stops at the first newline", async () => {
+    async function* chunks() { yield new TextEncoder().encode("1234"); yield new TextEncoder().encode("5"); }
+    expect(await readBoundedInput(chunks(), 4)).toBeNull();
+    let pulled = 0;
+    async function* endless() {
+      yield new TextEncoder().encode('{"action":"stop",');
+      yield new TextEncoder().encode('"name":"lab-search-1"}\ntrailing');
+      while (true) { pulled++; yield new TextEncoder().encode("x"); }
+    }
+    expect(await readBoundedInput(endless())).toBe('{"action":"stop","name":"lab-search-1"}');
+    expect(pulled).toBe(0);
+  });
+
+  test("the helper process exits promptly while stdin is still open", async () => {
+    const proc = Bun.spawn(["bun", new URL("./container-control.ts", import.meta.url).pathname], {
+      stdin: "pipe", stdout: "pipe", stderr: "ignore",
+    });
+    proc.stdin.write('{"action":"stop","name":"definitely-missing"}\n');
+    await proc.stdin.flush();
+    const started = performance.now();
+    const exit = await Promise.race([proc.exited, Bun.sleep(8000).then(() => "timeout" as const)]);
+    proc.kill();
+    expect(exit).not.toBe("timeout");
+    expect(performance.now() - started).toBeLessThan(7000);
+    const out = JSON.parse(await new Response(proc.stdout).text());
+    expect(out.ok).toBe(false);
+  });
+});

--- a/container-control.ts
+++ b/container-control.ts
@@ -1,0 +1,291 @@
+#!/usr/bin/env bun
+// Start or stop one container from the desk. The name is framed over stdin
+// and checked against a live `docker ps -a` / `podman ps -a` inventory before
+// any mutation. Names are argv elements, never a shell string.
+
+import { existsSync } from "fs";
+
+export type ContainerAction = "start" | "stop";
+export type ContainerEngine = "docker" | "podman";
+export type ContainerControlRequest = { action: ContainerAction; name: string };
+export type ContainerControlResult = {
+  ok: boolean;
+  action: string;
+  name: string;
+  message: string;
+};
+export type ContainerRow = {
+  id: string;
+  name: string;
+  label: string;
+  service: string;
+  project: string;
+  image: string;
+  state: string;
+  running: boolean;
+  health: string;
+};
+
+export const DOCKER_BIN = "/usr/bin/docker";
+export const PODMAN_BIN = "/usr/bin/podman";
+export const MAX_CONTAINERS = 32;
+export const MAX_INPUT_BYTES = 4096;
+export const MAX_LIST_BYTES = 256 * 1024;
+const CONTAINER_NAME = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,254}$/;
+const CONTAINER_ID = /^[a-f0-9]{12,64}$/i;
+const STATE = /^[a-z]{1,16}$/;
+const HEALTH = /^(healthy|unhealthy|starting)$/;
+
+export type RunCommand = (argv: string[], timeoutMs: number) => Promise<{ code: number; stdout: string }>;
+
+export function validContainerName(value: unknown): string {
+  const name = String(value || "").trim();
+  return CONTAINER_NAME.test(name) ? name : "";
+}
+
+export function containerEngine(which: (path: string) => boolean = existsSync): ContainerEngine | null {
+  if (which(DOCKER_BIN)) return "docker";
+  if (which(PODMAN_BIN)) return "podman";
+  return null;
+}
+
+export function containerListArgv(engine: ContainerEngine): string[] {
+  return engine === "docker"
+    ? [DOCKER_BIN, "ps", "-a", "--format", "{{json .}}"]
+    : [PODMAN_BIN, "ps", "-a", "--format", "json"];
+}
+
+export function containerMutateArgv(engine: ContainerEngine, action: ContainerAction, name: string): string[] {
+  return [engine === "docker" ? DOCKER_BIN : PODMAN_BIN, action, "--", name];
+}
+
+export function parseControlRequest(value: unknown): ContainerControlRequest | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const action = String((value as any).action || "");
+  const name = validContainerName((value as any).name);
+  if ((action !== "start" && action !== "stop") || !name) return null;
+  return { action, name };
+}
+
+function slug(value: unknown, limit = 128): string {
+  const text = String(value || "").trim().slice(0, limit);
+  return CONTAINER_NAME.test(text) ? text : "";
+}
+
+function shortImage(value: unknown): string {
+  const raw = String(value || "").trim().slice(0, 256);
+  if (!raw || raw.includes("\0") || /[\u0000-\u001f\u007f]/.test(raw)) return "";
+  const noDigest = raw.replace(/@sha256:[a-f0-9]{64}$/i, "");
+  const slash = noDigest.lastIndexOf("/");
+  const name = slash >= 0 ? noDigest.slice(slash + 1) : noDigest;
+  return name.slice(0, 64);
+}
+
+function composeField(labels: unknown, key: "project" | "service"): string {
+  const needle = `com.docker.compose.${key}`;
+  if (labels && typeof labels === "object" && !Array.isArray(labels)) {
+    return slug((labels as any)[needle]);
+  }
+  const text = String(labels || "");
+  const match = text.match(new RegExp(`${needle.replace(/\./g, "\\.")}=([^,]+)`));
+  return slug(match?.[1]);
+}
+
+function firstName(value: unknown): string {
+  if (Array.isArray(value)) return validContainerName(value[0]);
+  const text = String(value || "").trim();
+  return validContainerName(text.split(",")[0]);
+}
+
+function stateOf(row: any): string {
+  const raw = row && typeof row === "object" ? row.State : "";
+  const text = raw && typeof raw === "object"
+    ? String(raw.Status || raw.status || raw.StatusText || "")
+    : String(raw || "");
+  const state = text.trim().toLowerCase().slice(0, 16);
+  return STATE.test(state) ? state : "";
+}
+
+function healthOf(row: any, status: string): string {
+  const raw = String(row?.HealthStatus || row?.Health || "").trim().toLowerCase();
+  if (HEALTH.test(raw)) return raw;
+  const match = String(status || "").match(/\((healthy|unhealthy|starting)\)/i);
+  return match ? match[1].toLowerCase() : "";
+}
+
+function idOf(row: any): string {
+  const raw = String(row?.ID || row?.Id || "").trim().toLowerCase();
+  if (!CONTAINER_ID.test(raw)) return "";
+  return raw.slice(0, 12);
+}
+
+export function parseContainerRecord(row: unknown): ContainerRow | null {
+  if (!row || typeof row !== "object" || Array.isArray(row)) return null;
+  const item = row as any;
+  const name = firstName(item.Names ?? item.Name);
+  if (!name) return null;
+  const state = stateOf(item);
+  const status = String(item.Status || "");
+  const project = composeField(item.Labels, "project");
+  const service = composeField(item.Labels, "service");
+  return {
+    id: idOf(item),
+    name,
+    label: service || name,
+    service,
+    project,
+    image: shortImage(item.Image),
+    state,
+    running: state === "running",
+    health: healthOf(item, status),
+  };
+}
+
+function recordsFrom(text: string): unknown[] {
+  const raw = String(text || "").trim();
+  if (!raw) return [];
+  if (raw.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed.slice(0, MAX_CONTAINERS + 1) : [];
+    } catch { return []; }
+  }
+  const out: unknown[] = [];
+  for (const line of raw.split("\n")) {
+    if (out.length > MAX_CONTAINERS) break;
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) continue;
+    try { out.push(JSON.parse(trimmed)); } catch {}
+  }
+  return out;
+}
+
+export function parseContainerList(text: string): ContainerRow[] {
+  const seen = new Set<string>();
+  const items: ContainerRow[] = [];
+  for (const record of recordsFrom(text)) {
+    if (items.length >= MAX_CONTAINERS) break;
+    const row = parseContainerRecord(record);
+    if (!row || seen.has(row.name)) continue;
+    seen.add(row.name);
+    items.push(row);
+  }
+  const projects = new Set(items.map(item => item.project).filter(Boolean));
+  for (const item of items) {
+    if (item.service) item.label = projects.size > 1 && item.project ? item.project + "/" + item.service : item.service;
+  }
+  items.sort((a, b) => Number(b.running) - Number(a.running) || a.label.localeCompare(b.label));
+  return items;
+}
+
+async function defaultRun(argv: string[], timeoutMs: number): Promise<{ code: number; stdout: string }> {
+  try {
+    const proc = Bun.spawn(argv, { stdout: "pipe", stderr: "ignore" });
+    let expired: ReturnType<typeof setTimeout> | null = null;
+    const deadline = new Promise<null>(resolve => { expired = setTimeout(() => resolve(null), timeoutMs); });
+    try {
+      const chunks: Uint8Array[] = [];
+      let total = 0;
+      const reader = proc.stdout.getReader();
+      const readAll = (async () => {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          total += value.byteLength;
+          if (total > MAX_LIST_BYTES) { try { proc.kill("SIGKILL"); } catch {} return null; }
+          chunks.push(value);
+        }
+        const bytes = new Uint8Array(total);
+        let offset = 0;
+        for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.byteLength; }
+        return new TextDecoder().decode(bytes);
+      })();
+      const out = await Promise.race([readAll, deadline]);
+      if (out === null) {
+        try { proc.kill("SIGTERM"); } catch {}
+        await Promise.race([proc.exited, new Promise(resolve => setTimeout(resolve, 250))]);
+        try { proc.kill("SIGKILL"); } catch {}
+        await Promise.race([proc.exited, new Promise(resolve => setTimeout(resolve, 250))]);
+        return { code: 1, stdout: "" };
+      }
+      let grace: ReturnType<typeof setTimeout> | null = null;
+      const code = await Promise.race([
+        proc.exited,
+        new Promise<number>(resolve => {
+          grace = setTimeout(() => {
+            try { proc.kill("SIGKILL"); } catch {}
+            resolve(1);
+          }, 2000);
+        }),
+      ]);
+      if (grace) clearTimeout(grace);
+      return { code: typeof code === "number" ? code : 1, stdout: out };
+    } finally {
+      if (expired) clearTimeout(expired);
+    }
+  } catch {
+    return { code: 1, stdout: "" };
+  }
+}
+
+export async function controlContainer(
+  value: unknown,
+  engine: ContainerEngine | null = containerEngine(),
+  run: RunCommand = defaultRun,
+): Promise<ContainerControlResult> {
+  const request = parseControlRequest(value);
+  if (!request) return { ok: false, action: "", name: "", message: "Invalid container control request" };
+  if (!engine) return { ok: false, action: request.action, name: request.name, message: "No container engine" };
+
+  const listed = await run(containerListArgv(engine), 3000);
+  const items = parseContainerList(listed.stdout);
+  const match = items.find(item => item.name === request.name);
+  if (!match) return { ok: false, action: request.action, name: request.name, message: "Container is not in the live inventory" };
+  if (request.action === "start" && match.running)
+    return { ok: true, action: request.action, name: request.name, message: "Already running" };
+  if (request.action === "stop" && !match.running)
+    return { ok: true, action: request.action, name: request.name, message: "Already stopped" };
+
+  const mutated = await run(containerMutateArgv(engine, request.action, match.name), request.action === "stop" ? 20000 : 15000);
+  if (mutated.code !== 0) {
+    return { ok: false, action: request.action, name: request.name, message: `Container ${request.action} failed` };
+  }
+  return {
+    ok: true,
+    action: request.action,
+    name: request.name,
+    message: request.action === "start" ? "Container started" : "Container stopped",
+  };
+}
+
+export async function readBoundedInput(stream: AsyncIterable<Uint8Array | string>, limit = MAX_INPUT_BYTES): Promise<string | null> {
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for await (const raw of stream) {
+    const chunk = typeof raw === "string" ? new TextEncoder().encode(raw) : raw;
+    const newline = chunk.indexOf(0x0a);
+    const piece = newline >= 0 ? chunk.subarray(0, newline) : chunk;
+    total += piece.byteLength;
+    if (total > limit) return null;
+    chunks.push(piece);
+    if (newline >= 0) break;
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.byteLength; }
+  return new TextDecoder().decode(bytes);
+}
+
+if (import.meta.main) {
+  let result: ContainerControlResult;
+  const input = await readBoundedInput(process.stdin);
+  try {
+    result = input === null
+      ? { ok: false, action: "", name: "", message: "Container control input exceeded 4 KiB" }
+      : await controlContainer(JSON.parse(input));
+  } catch {
+    result = { ok: false, action: "", name: "", message: "Invalid container control frame" };
+  }
+  process.stdout.write(JSON.stringify(result) + "\n");
+  process.exit(result.ok ? 0 : 1);
+}

--- a/info-ui.test.ts
+++ b/info-ui.test.ts
@@ -16,6 +16,7 @@ describe("interactive information modules", () => {
     expect(adjacentEnabledIndex(["usage", "localAi", "machine"], 0, 1, { localAi: false })).toBe(2);
     expect(adjacentEnabledIndex(["changes", "needs", "projects"], 2, -1, { needs: false })).toBe(0);
     expect(adjacentEnabledIndex(["usage", "localAi", "machine"], 0, -1, {})).toBe(0);
+    expect(adjacentEnabledIndex(["usage", "localAi", "machine", "media", "containers"], 2, 1, {})).toBe(3);
     expect(settings).toContain("adjacentEnabledIndex(next, from, direction, sections)");
   });
 
@@ -357,6 +358,24 @@ describe("right column fits a 1080p desk", () => {
   });
 });
 
+describe("containers card", () => {
+  test("registers a reorderable lower-right module with per-row on/off toggles", () => {
+    expect(settings).toContain('{ id: "containers", label: "CONTAINERS" }');
+    expect(settings).toContain('property var rightOrder: ["usage", "localAi", "machine", "media", "containers"]');
+    expect(settings).toContain('var allowed = ["usage", "localAi", "machine", "media", "containers"]');
+    expect(view).toContain('title: "CONTAINERS"');
+    expect(view).toContain('moveId: "containers"');
+    expect(view).toContain("component PowerToggle: Item");
+    expect(view).toContain('view.desk.controlContainer(item.running ? "stop" : "start", item.name)');
+    expect(view).toContain("readonly property int visibleLimit: 8");
+    expect(view).toContain('visible: view.sectionEnabled("usage") || view.sectionEnabled("localAi") || view.sectionEnabled("machine") || view.sectionEnabled("media") || view.sectionEnabled("containers")');
+    expect(model).toContain('containerControlPath: Qt.resolvedUrl("container-control.ts")');
+    expect(model).toContain("containerProcess.pendingFrame");
+    expect(model).toContain('["start", "stop"].indexOf(operation)');
+    expect(view).toContain("lit: !!modelData.running");
+  });
+});
+
 describe("LOCAL AI rows stay inside the card body", () => {
   const view = readFileSync(join(import.meta.dir, "InfoView.qml"), "utf8");
   test("the provider chips are a Flow, so no rigid row can raise the column minimum above the body width", () => {
@@ -426,13 +445,15 @@ describe("github activity heatmap", () => {
   test("registers GITHUB as a removable module beside ACTIVITY and reaches it from the keyboard", () => {
     const ids = [...settings.matchAll(/\{ id: "([a-zA-Z]+)", label: "[^"]+" \}/g)].map(match => match[1]);
     expect(ids.indexOf("github")).toBe(ids.indexOf("activity") + 1);
-    expect(ids).toHaveLength(11);
+    expect(ids).toHaveLength(12);
     expect(ids[10]).toBe("media");
+
     expect(overlay).toContain("event.key >= Qt.Key_0 && event.key <= Qt.Key_9");
     expect(overlay).toContain("event.key === Qt.Key_0 ? 9 : event.key - Qt.Key_1");
     // Key n toggles definitions[n-1]; 0 is the tenth. Documented as 4 = GITHUB, 0 = PROJECTS.
     expect(ids[3]).toBe("github");
     expect(ids[9]).toBe("projects");
+    expect(ids[11]).toBe("containers");
   });
 
   test("splits the activity row into two half-width heatmap cards sharing one HeatPanel", () => {
@@ -475,7 +496,7 @@ test("persisted Ollama origins reject credentials and request paths", () => {
 describe("media controls card", () => {
   test("registers a reorderable lower-right MPRIS card with prev/play/next and a title line", () => {
     expect(settings).toContain('{ id: "media", label: "MEDIA" }');
-    expect(settings).toContain('property var rightOrder: ["usage", "localAi", "machine", "media"]');
+    expect(settings).toContain('property var rightOrder: ["usage", "localAi", "machine", "media", "containers"]');
     expect(view).toContain('title: "MEDIA CONTROLS"');
     expect(view).toContain('moveId: "media"');
     expect(view).toContain("import Quickshell.Services.Mpris");

--- a/qml-resolve.test.ts
+++ b/qml-resolve.test.ts
@@ -22,12 +22,14 @@ import { join } from "path";
 // A ceiling still catches the case that matters: one new unresolvable
 // reference moves the count, which is exactly what a bad merge introduces.
 // Verified — the same injection took InfoModel from 5 to 6.
+// Container additions: one Process exit-status metadata warning, plus
+// dynamic Style properties and unqualified card/delegate accesses.
 const CEILINGS: Record<string, number> = {
   "BackgroundWallpaper.qml": 2,
   "Infomarchy.qml": 26,
-  "InfoModel.qml": 5,
+  "InfoModel.qml": 6,
   "InfoSettings.qml": 0,
-  "InfoView.qml": 473,
+  "InfoView.qml": 511,
   "Overlay.qml": 29,
   "WaveWallpaper.qml": 0,
 };


### PR DESCRIPTION
This adds a hideable, reorderable CONTAINERS card to the existing right column, showing up to eight Docker or Podman containers with explicit start/stop toggles.

Collection drops compose working directories, env files, commands, mounts and ports. The control helper accepts a bounded JSON request, checks a live inventory, and passes the matched container name as its own argv element. Docker is preferred when installed; `INFOMARCHY_SKIP_CONTAINERS=1` skips collection.

Validation on upstream `9726812` (1.4.1): `PATH=/usr/bin:$PATH bun test --timeout 30000` passed 241 tests across 16 files, including both QML syntax and real-import resolution gates. `git diff --check` passed. The explicit PATH makes isolated-HOME collector fixtures use the installed Bun binary.

The module list now contains 12 entries. The default right-column order is `usage, localAi, machine, media, containers`, with matching normalization and UI assertions.
