### PR TITLE
feat: recognize Antigravity and agy as an agent provider

### DIFF
--- a/InfoModel.qml
+++ b/InfoModel.qml
@@ -123,6 +123,7 @@ Item {
       case "grok-bot": return root.magenta
       case "gemini": return root.blue
       case "hermes": return root.green
+      case "antigravity": return root.blue
       case "ollama": return root.green
       case "opencode": return root.blue
       case "aider": return root.yellow
@@ -151,6 +152,7 @@ Item {
       case "grok-bot": return "Grok Bot"
       case "gemini": return "Gemini"
       case "hermes": return "Hermes"
+      case "antigravity": return "Antigravity"
       case "ollama": return "Ollama"
       case "opencode": return "opencode"
       case "aider": return "Aider"

--- a/collector.test.ts
+++ b/collector.test.ts
@@ -76,6 +76,13 @@ describe("providerOf", () => {
   test("recognizes Hermes as an interactive agent provider", () => {
     expect(providerOf(["/home/user/.hermes/bin/hermes"])).toBe("hermes");
   });
+
+  test("recognizes Antigravity and agy, ignoring background services", () => {
+    expect(providerOf(["/usr/bin/antigravity"])).toBe("antigravity");
+    expect(providerOf(["agy"])).toBe("antigravity");
+    expect(providerOf(["agy", "remote-control", "start"])).toBeNull();
+    expect(providerOf(["agy", "mic-serve"])).toBeNull();
+  });
 });
 
 describe("multiplexer session identity", () => {

--- a/collector.ts
+++ b/collector.ts
@@ -521,6 +521,9 @@ const PROVIDERS: [string, RegExp][] = [
   ["grok-bot", /(^|\/)grok-bot(\s|$)/],
   ["gemini", /(^|\/)gemini(\.js|\.mjs)?$/],
   ["hermes", /(^|\/)hermes(\.js|\.mjs|\.py)?$/],
+  // "agy" is the CLI's own short name (its mise shim resolves to the same
+  // binary as "antigravity"); both launch the identical program.
+  ["antigravity", /(^|\/)(antigravity|agy)$/],
   ["opencode", /(^|\/)opencode$/],
   ["aider", /(^|\/)aider$/],
   ["copilot", /(^|\/)copilot$/],
@@ -556,6 +559,10 @@ export function providerOf(cmd: string[]): string | null {
       // OpenCode also exposes several persistent services. Only its TUI/run
       // invocations represent a session that belongs on the desk.
       if (name === "opencode" && cmd.some(a => ["serve", "web", "acp", "mcp", "github"].includes(a))) return null;
+      // `agy remote-control start` and `agy mic-serve` are background
+      // services (a remote-access daemon and a mic-forwarding server), not
+      // an agent conversation — same shape as Codex's app-server exclusion.
+      if (name === "antigravity" && cmd.some(a => a === "remote-control" || a === "mic-serve")) return null;
       return name;
     }
   }


### PR DESCRIPTION
Resolves #23.

Adds support for tracking Google Antigravity (`antigravity` and `agy`) agent sessions on the Infomarchy wallpaper desk.

### Changes
- **`collector.ts`**:
  - Registers `antigravity` in `PROVIDERS` matching `antigravity` and its short name `agy`.
  - Excludes `agy remote-control start` and `agy mic-serve` background daemons so only interactive agent sessions show on the desk.
- **`InfoModel.qml`**:
  - Adds the `root.blue` badge color role and the `"Antigravity"` display name.
- **`collector.test.ts`**:
  - Adds unit tests verifying provider recognition for both binary names and exclusion of background services.

### Sample Process Data
Interactive sessions:
```
/usr/bin/antigravity
agy
```

Excluded daemons:
```
agy remote-control start
agy mic-serve
```

### Validation
Ran `bun test`: all 200 tests pass.