### PR TITLE
fix: remove accidentally committed node_modules symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-node_modules/
+node_modules
 *.log
 .test-fixture*

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/pi/Projects/infomarchy/node_modules


### PR DESCRIPTION
### Summary

Commit 174cd26 accidentally tracked `node_modules` as a symlink pointing to `/home/pi/Projects/infomarchy/node_modules`.

Because Omarchy's `omarchy-plugin-validate` refuses any symlinks inside plugin folders for security reasons:
```
omarchy-plugin-validate: symlinks are not allowed inside a plugin folder: .../nixfred.infomarchy/node_modules
omarchy-plugin-update: update of 'nixfred.infomarchy' failed validation; rolled back
```
running `omarchy plugin update` fails validation and rolls back for all Omarchy users.

### Changes
- Removes `node_modules` symlink from git.
- Updates `.gitignore` from `node_modules/` to `node_modules` so that symlinks pointing to directories are also ignored by git.

### Validation
- `bun test`: all 231 tests pass.
- `omarchy plugin validate`: passes.